### PR TITLE
Allow setting limit to disk space (Phase 1/2)

### DIFF
--- a/examples/example_inprocess_cache_eviction.rs
+++ b/examples/example_inprocess_cache_eviction.rs
@@ -30,7 +30,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         storage
             .storage()
             .insert(entry_id, arrow_array.clone())
-            .await;
+            .await
+            .unwrap();
         let _ = storage.storage().get(&entry_id).await.unwrap();
     }
     println!("{:?}", storage.storage().stats());

--- a/examples/example_inprocess_insertion.rs
+++ b/examples/example_inprocess_insertion.rs
@@ -28,7 +28,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     storage
         .storage()
         .insert(entry_id, arrow_array.clone())
-        .await;
+        .await
+        .unwrap();
 
     assert!(storage.storage().is_cached(&entry_id));
 

--- a/examples/example_inprocess_read.rs
+++ b/examples/example_inprocess_read.rs
@@ -9,10 +9,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let entry_id = EntryID::from(7);
     let arrow_array = Arc::new(UInt64Array::from_iter_values(0..16));
-    storage.insert(entry_id, arrow_array.clone()).await;
+    storage.insert(entry_id, arrow_array.clone()).await.unwrap();
 
     // Move data to disk so the read will demonstrate async I/O
-    storage.flush_all_to_disk().await;
+    storage.flush_all_to_disk().await.unwrap();
 
     // Read asynchronously
     let retrieved = storage.get(&entry_id).await.unwrap();

--- a/src/core/src/cache/budget.rs
+++ b/src/core/src/cache/budget.rs
@@ -1,18 +1,30 @@
-use crate::sync::atomic::{AtomicUsize, Ordering};
+use super::observer::Observer;
+use crate::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
 #[derive(Debug)]
 pub struct BudgetAccounting {
     max_memory_bytes: usize,
+    max_disk_bytes: usize,
     used_memory_bytes: AtomicUsize,
     used_disk_bytes: AtomicUsize,
+    observer: Arc<Observer>,
 }
 
 impl BudgetAccounting {
-    pub(super) fn new(max_memory_bytes: usize) -> Self {
+    pub(super) fn new(
+        max_memory_bytes: usize,
+        max_disk_bytes: usize,
+        observer: Arc<Observer>,
+    ) -> Self {
         Self {
             max_memory_bytes,
+            max_disk_bytes,
             used_memory_bytes: AtomicUsize::new(0),
             used_disk_bytes: AtomicUsize::new(0),
+            observer,
         }
     }
 
@@ -66,8 +78,27 @@ impl BudgetAccounting {
         self.used_disk_bytes.load(Ordering::Relaxed)
     }
 
-    pub fn add_used_disk_bytes(&self, bytes: usize) {
-        self.used_disk_bytes.fetch_add(bytes, Ordering::Relaxed);
+    pub(super) fn try_reserve_disk(&self, request_bytes: usize) -> Result<(), ()> {
+        let used = self.used_disk_bytes.load(Ordering::Relaxed);
+        if used + request_bytes > self.max_disk_bytes {
+            self.observer.on_disk_reservation_failure();
+            return Err(());
+        }
+
+        match self.used_disk_bytes.compare_exchange(
+            used,
+            used + request_bytes,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => Ok(()),
+            Err(_) => self.try_reserve_disk(request_bytes),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn release_disk(&self, bytes: usize) {
+        self.used_disk_bytes.fetch_sub(bytes, Ordering::Relaxed);
     }
 }
 
@@ -76,9 +107,13 @@ mod tests {
     use super::*;
     use crate::sync::{Arc, Barrier, thread};
 
+    fn test_budget(max_memory_bytes: usize, max_disk_bytes: usize) -> BudgetAccounting {
+        BudgetAccounting::new(max_memory_bytes, max_disk_bytes, Arc::new(Observer::new()))
+    }
+
     #[test]
     fn test_memory_reservation_and_accounting() {
-        let config = BudgetAccounting::new(1000);
+        let config = test_budget(1000, usize::MAX);
 
         assert_eq!(config.memory_usage_bytes(), 0);
 
@@ -111,7 +146,7 @@ mod tests {
         let max_memory = 10000;
         let operations_per_thread = 100;
 
-        let budget = Arc::new(BudgetAccounting::new(max_memory));
+        let budget = Arc::new(test_budget(max_memory, usize::MAX));
         let barrier = Arc::new(Barrier::new(num_threads));
 
         let mut thread_handles = vec![];
@@ -164,5 +199,23 @@ mod tests {
 
         assert_eq!(budget.memory_usage_bytes(), expected_memory_usage);
         assert!(budget.memory_usage_bytes() <= max_memory);
+    }
+
+    #[test]
+    fn disk_reservation_and_release() {
+        let budget = test_budget(usize::MAX, 1000);
+
+        assert_eq!(budget.disk_usage_bytes(), 0);
+        assert!(budget.try_reserve_disk(400).is_ok());
+        assert_eq!(budget.disk_usage_bytes(), 400);
+        assert!(budget.try_reserve_disk(600).is_ok());
+        assert_eq!(budget.disk_usage_bytes(), 1000);
+        assert!(budget.try_reserve_disk(1).is_err());
+        assert_eq!(budget.disk_usage_bytes(), 1000);
+
+        budget.release_disk(250);
+        assert_eq!(budget.disk_usage_bytes(), 750);
+        assert!(budget.try_reserve_disk(250).is_ok());
+        assert_eq!(budget.disk_usage_bytes(), 1000);
     }
 }

--- a/src/core/src/cache/builders.rs
+++ b/src/core/src/cache/builders.rs
@@ -10,7 +10,7 @@ use super::cached_batch::CacheEntry;
 use super::core::LiquidCache;
 use super::io_context::{DefaultCacheMetadata, EntryMetadata};
 use super::policies::{CachePolicy, HydrationPolicy, SqueezePolicy, TranscodeSqueezeEvict};
-use super::{CacheExpression, EntryID, LiquidExpr, LiquidPolicy};
+use super::{CacheExpression, CacheFull, EntryID, LiquidExpr, LiquidPolicy};
 use crate::sync::Arc;
 
 /// Builder for [LiquidCache].
@@ -32,6 +32,7 @@ use crate::sync::Arc;
 pub struct LiquidCacheBuilder {
     batch_size: usize,
     max_memory_bytes: usize,
+    max_disk_bytes: usize,
     cache_policy: Box<dyn CachePolicy>,
     hydration_policy: Box<dyn HydrationPolicy>,
     squeeze_policy: Box<dyn SqueezePolicy>,
@@ -52,6 +53,7 @@ impl LiquidCacheBuilder {
         Self {
             batch_size: 8192,
             max_memory_bytes: 1024 * 1024 * 1024,
+            max_disk_bytes: usize::MAX,
             cache_policy: Box::new(LiquidPolicy::new()),
             hydration_policy: Box::new(super::AlwaysHydrate::new()),
             squeeze_policy: Box::new(TranscodeSqueezeEvict),
@@ -72,6 +74,13 @@ impl LiquidCacheBuilder {
     /// Default is 1GB.
     pub fn with_max_memory_bytes(mut self, max_memory_bytes: usize) -> Self {
         self.max_memory_bytes = max_memory_bytes;
+        self
+    }
+
+    /// Set the max disk bytes for the cache.
+    /// Default is unlimited.
+    pub fn with_max_disk_bytes(mut self, max_disk_bytes: usize) -> Self {
+        self.max_disk_bytes = max_disk_bytes;
         self
     }
 
@@ -137,6 +146,7 @@ impl LiquidCacheBuilder {
         Arc::new(LiquidCache::new(
             self.batch_size,
             self.max_memory_bytes,
+            self.max_disk_bytes,
             self.squeeze_policy,
             self.cache_policy,
             self.hydration_policy,
@@ -180,7 +190,7 @@ impl<'a> Insert<'a> {
         self
     }
 
-    async fn run(self) {
+    async fn run(self) -> Result<(), CacheFull> {
         let batch = if self.skip_gc {
             self.batch.clone()
         } else {
@@ -190,13 +200,13 @@ impl<'a> Insert<'a> {
             self.storage.add_squeeze_hint(&self.entry_id, squeeze_hint);
         }
         let batch = CacheEntry::memory_arrow(batch);
-        self.storage.insert_inner(self.entry_id, batch).await;
+        self.storage.insert_inner(self.entry_id, batch).await
     }
 }
 
 impl<'a> IntoFuture for Insert<'a> {
-    type Output = ();
-    type IntoFuture = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+    type Output = Result<(), CacheFull>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Result<(), CacheFull>> + Send + 'a>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move { self.run().await })
@@ -429,7 +439,7 @@ mod tests {
 
         let cache = LiquidCacheBuilder::new().build().await;
         let entry_id = EntryID::from(123usize);
-        cache.insert(entry_id, root.clone()).await;
+        cache.insert(entry_id, root.clone()).await.unwrap();
 
         let stored = cache.get(&entry_id).await.expect("array present");
         let post_size = stored.get_array_memory_size();

--- a/src/core/src/cache/core.rs
+++ b/src/core/src/cache/core.rs
@@ -19,7 +19,7 @@ use crate::cache::DefaultSqueezeIo;
 use crate::cache::policies::SqueezePolicy;
 use crate::cache::utils::{LiquidCompressorStates, arrow_to_bytes};
 use crate::cache::{CacheExpression, LiquidExpr, index::ArtIndex, utils::EntryID};
-use crate::cache::{CacheStats, EventTrace};
+use crate::cache::{CacheFull, CacheStats, EventTrace};
 use crate::liquid_array::{
     LiquidSqueezedArrayRef, SqueezeIoHandler, SqueezedBacking, SqueezedDate32Array,
     VariantStructSqueezedArray,
@@ -113,6 +113,7 @@ impl LiquidCache {
             memory_usage_bytes,
             disk_usage_bytes,
             max_memory_bytes: self.config.max_memory_bytes(),
+            max_disk_bytes: self.config.max_disk_bytes(),
             runtime,
         }
     }
@@ -209,6 +210,11 @@ impl LiquidCache {
         &self.observer
     }
 
+    /// Record that a parquet row group bypassed the cache because it was full.
+    pub fn record_cache_full_bypass(&self) {
+        self.observer.on_cache_full_bypass();
+    }
+
     /// Get the compressor states of the cache.
     pub fn compressor_states(&self, entry_id: &EntryID) -> Arc<LiquidCompressorStates> {
         self.metadata.get_compressor(entry_id)
@@ -220,7 +226,7 @@ impl LiquidCache {
     }
 
     /// Flush all entries to disk.
-    pub async fn flush_all_to_disk(&self) {
+    pub async fn flush_all_to_disk(&self) -> Result<(), CacheFull> {
         let mut entires = Vec::new();
         self.for_each_entry(|entry_id, batch| {
             entires.push((*entry_id, batch.clone()));
@@ -229,14 +235,14 @@ impl LiquidCache {
             match &batch {
                 CacheEntry::MemoryArrow(array) => {
                     let bytes = arrow_to_bytes(array).expect("failed to convert arrow to bytes");
-                    self.write_batch_to_disk(entry_id, &batch, bytes).await;
+                    self.write_batch_to_disk(entry_id, &batch, bytes).await?;
                     self.try_insert(entry_id, CacheEntry::disk_arrow(array.data_type().clone()))
                         .expect("failed to insert disk arrow entry");
                 }
                 CacheEntry::MemoryLiquid(liquid_array) => {
                     let liquid_bytes = liquid_array.to_bytes();
                     self.write_batch_to_disk(entry_id, &batch, Bytes::from(liquid_bytes))
-                        .await;
+                        .await?;
                     self.try_insert(
                         entry_id,
                         CacheEntry::disk_liquid(liquid_array.original_arrow_data_type()),
@@ -254,6 +260,7 @@ impl LiquidCache {
                 }
             }
         }
+        Ok(())
     }
 }
 
@@ -263,7 +270,7 @@ impl LiquidCache {
         &self,
         entry_id: EntryID,
         batch: CacheEntry,
-    ) -> CacheEntry {
+    ) -> Result<CacheEntry, CacheFull> {
         match &batch {
             batch @ CacheEntry::MemoryArrow(_) => {
                 let squeeze_io: Arc<dyn SqueezeIoHandler> = Arc::new(DefaultSqueezeIo::new(
@@ -279,24 +286,27 @@ impl LiquidCache {
                 );
                 if let Some(bytes_to_write) = bytes_to_write {
                     self.write_batch_to_disk(entry_id, &new_batch, bytes_to_write)
-                        .await;
+                        .await?;
                 }
-                new_batch
+                Ok(new_batch)
             }
             CacheEntry::MemoryLiquid(liquid_array) => {
                 let liquid_bytes = Bytes::from(liquid_array.to_bytes());
                 self.write_batch_to_disk(entry_id, &batch, liquid_bytes)
-                    .await;
-                CacheEntry::disk_liquid(liquid_array.original_arrow_data_type())
+                    .await?;
+                Ok(CacheEntry::disk_liquid(
+                    liquid_array.original_arrow_data_type(),
+                ))
             }
             CacheEntry::MemorySqueezedLiquid(squeezed_array) => {
                 // The full data is already on disk, so we just need to mark ourself as disk entry
                 let backing = squeezed_array.disk_backing();
-                if backing == SqueezedBacking::Liquid {
+                let entry = if backing == SqueezedBacking::Liquid {
                     CacheEntry::disk_liquid(squeezed_array.original_arrow_data_type())
                 } else {
                     CacheEntry::disk_arrow(squeezed_array.original_arrow_data_type())
-                }
+                };
+                Ok(entry)
             }
             CacheEntry::DiskLiquid(_) | CacheEntry::DiskArrow(_) => {
                 unreachable!("Unexpected batch in write_in_memory_batch_to_disk")
@@ -305,10 +315,14 @@ impl LiquidCache {
     }
 
     /// Insert a batch into the cache, it will run cache replacement policy until the batch is inserted.
-    pub(crate) async fn insert_inner(&self, entry_id: EntryID, mut batch_to_cache: CacheEntry) {
+    pub(crate) async fn insert_inner(
+        &self,
+        entry_id: EntryID,
+        mut batch_to_cache: CacheEntry,
+    ) -> Result<(), CacheFull> {
         loop {
             let Err(not_inserted) = self.try_insert(entry_id, batch_to_cache) else {
-                return;
+                return Ok(());
             };
             self.trace(InternalEvent::InsertFailed {
                 entry: entry_id,
@@ -322,11 +336,11 @@ impl LiquidCache {
                 // we write it to disk
                 let on_disk_batch = self
                     .write_in_memory_batch_to_disk(entry_id, not_inserted)
-                    .await;
+                    .await?;
                 batch_to_cache = on_disk_batch;
                 continue;
             }
-            self.squeeze_victims(victims).await;
+            self.squeeze_victims(victims).await?;
 
             batch_to_cache = not_inserted;
             crate::utils::yield_now_if_shuttle();
@@ -338,6 +352,7 @@ impl LiquidCache {
     pub(crate) fn new(
         batch_size: usize,
         max_memory_bytes: usize,
+        max_disk_bytes: usize,
         squeeze_policy: Box<dyn SqueezePolicy>,
         cache_policy: Box<dyn CachePolicy>,
         hydration_policy: Box<dyn HydrationPolicy>,
@@ -345,15 +360,20 @@ impl LiquidCache {
         store: t4::Store,
         squeeze_victims_concurrently: bool,
     ) -> Self {
-        let config = CacheConfig::new(batch_size, max_memory_bytes);
+        let config = CacheConfig::new(batch_size, max_memory_bytes, max_disk_bytes);
+        let observer = Arc::new(Observer::new());
         Self {
             index: ArtIndex::new(),
-            budget: BudgetAccounting::new(config.max_memory_bytes()),
+            budget: BudgetAccounting::new(
+                config.max_memory_bytes(),
+                config.max_disk_bytes(),
+                observer.clone(),
+            ),
             config,
             cache_policy,
             hydration_policy,
             squeeze_policy,
-            observer: Arc::new(Observer::new()),
+            observer,
             metadata,
             store,
             squeeze_victims_concurrently,
@@ -409,26 +429,28 @@ impl LiquidCache {
     }
 
     #[fastrace::trace]
-    async fn squeeze_victims(&self, victims: Vec<EntryID>) {
+    async fn squeeze_victims(&self, victims: Vec<EntryID>) -> Result<(), CacheFull> {
         self.trace(InternalEvent::SqueezeBegin {
             victims: victims.clone(),
         });
         if self.squeeze_victims_concurrently {
-            futures::stream::iter(victims)
-                .for_each_concurrent(None, |victim| async move {
-                    self.squeeze_victim_inner(victim).await;
-                })
+            let results = futures::stream::iter(victims)
+                .map(|victim| self.squeeze_victim_inner(victim))
+                .buffer_unordered(usize::MAX)
+                .collect::<Vec<_>>()
                 .await;
+            results.into_iter().collect::<Result<Vec<_>, _>>()?;
         } else {
             for victim in victims {
-                self.squeeze_victim_inner(victim).await;
+                self.squeeze_victim_inner(victim).await?;
             }
         }
+        Ok(())
     }
 
-    async fn squeeze_victim_inner(&self, to_squeeze: EntryID) {
+    async fn squeeze_victim_inner(&self, to_squeeze: EntryID) -> Result<(), CacheFull> {
         let Some(mut to_squeeze_batch) = self.index.get(&to_squeeze) else {
-            return;
+            return Ok(());
         };
         self.trace(InternalEvent::SqueezeVictim { entry: to_squeeze });
         let compressor = self.metadata.get_compressor(&to_squeeze);
@@ -450,7 +472,7 @@ impl LiquidCache {
 
             if let Some(bytes_to_write) = bytes_to_write {
                 self.write_batch_to_disk(to_squeeze, &new_batch, bytes_to_write)
-                    .await;
+                    .await?;
             }
             match self.try_insert(to_squeeze, new_batch) {
                 Ok(()) => {
@@ -461,6 +483,7 @@ impl LiquidCache {
                 }
             }
         }
+        Ok(())
     }
 
     fn disk_entry_from_squeezed(array: &LiquidSqueezedArrayRef) -> CacheEntry {
@@ -493,7 +516,7 @@ impl LiquidCache {
                 cached: cached_type,
                 new: new_type,
             });
-            self.insert_inner(*entry_id, new_entry).await;
+            let _ = self.insert_inner(*entry_id, new_entry).await;
         }
     }
 
@@ -692,18 +715,24 @@ impl LiquidCache {
         }
     }
 
-    async fn write_batch_to_disk(&self, entry_id: EntryID, batch: &CacheEntry, bytes: Bytes) {
+    async fn write_batch_to_disk(
+        &self,
+        entry_id: EntryID,
+        batch: &CacheEntry,
+        bytes: Bytes,
+    ) -> Result<(), CacheFull> {
+        let len = bytes.len();
+        self.budget.try_reserve_disk(len).map_err(|()| CacheFull)?;
         self.trace(InternalEvent::IoWrite {
             entry: entry_id,
             kind: CachedBatchType::from(batch),
-            bytes: bytes.len(),
+            bytes: len,
         });
-        let len = bytes.len();
         self.store
             .put(entry_id_to_key(&entry_id), bytes.to_vec())
             .await
             .expect("write failed");
-        self.budget.add_used_disk_bytes(len);
+        Ok(())
     }
 
     async fn read_disk_arrow_array(&self, entry_id: &EntryID) -> ArrayRef {
@@ -908,7 +937,7 @@ mod tests {
         let entry_id1: EntryID = EntryID::from(1);
         let array1 = create_test_array(100);
         let size1 = array1.memory_usage_bytes();
-        store.insert_inner(entry_id1, array1).await;
+        store.insert_inner(entry_id1, array1).await.unwrap();
 
         // Verify budget usage and data correctness
         assert_eq!(store.budget.memory_usage_bytes(), size1);
@@ -921,13 +950,13 @@ mod tests {
         let entry_id2: EntryID = EntryID::from(2);
         let array2 = create_test_array(200);
         let size2 = array2.memory_usage_bytes();
-        store.insert_inner(entry_id2, array2).await;
+        store.insert_inner(entry_id2, array2).await.unwrap();
 
         assert_eq!(store.budget.memory_usage_bytes(), size1 + size2);
 
         let array3 = create_test_array(150);
         let size3 = array3.memory_usage_bytes();
-        store.insert_inner(entry_id1, array3).await;
+        store.insert_inner(entry_id1, array3).await.unwrap();
 
         assert_eq!(store.budget.memory_usage_bytes(), size3 + size2);
         assert!(store.index().get(&EntryID::from(999)).is_none());
@@ -948,7 +977,8 @@ mod tests {
                 entry_id,
                 CacheEntry::memory_squeezed_liquid(squeezed.clone()),
             )
-            .await;
+            .await
+            .unwrap();
 
         let expr = Arc::new(CacheExpression::extract_date32(Date32Field::Year));
         let result = store
@@ -982,13 +1012,19 @@ mod tests {
             let advisor = TestPolicy::new(Some(entry_id1));
             let store = create_cache_store(8000, Box::new(advisor)).await; // Small budget to force advice
 
-            store.insert_inner(entry_id1, create_test_array(800)).await;
+            store
+                .insert_inner(entry_id1, create_test_array(800))
+                .await
+                .unwrap();
             match store.index().get(&entry_id1).unwrap().as_ref() {
                 CacheEntry::MemoryArrow(_) => {}
                 other => panic!("Expected ArrowMemory, got {other:?}"),
             }
 
-            store.insert_inner(entry_id2, create_test_array(800)).await;
+            store
+                .insert_inner(entry_id2, create_test_array(800))
+                .await
+                .unwrap();
             match store.index().get(&entry_id1).unwrap().as_ref() {
                 CacheEntry::MemoryLiquid(_) => {}
                 other => panic!("Expected LiquidMemory after eviction, got {other:?}"),
@@ -1036,7 +1072,7 @@ mod tests {
                         let unique_id = thread_id * ops_per_thread + i;
                         let entry_id: EntryID = EntryID::from(unique_id);
                         let array = create_test_arrow_array(100);
-                        store.insert(entry_id, array).await;
+                        store.insert(entry_id, array).await.unwrap();
                     }
                 });
             }));
@@ -1070,8 +1106,8 @@ mod tests {
         // Insert two small batches
         let arr1: ArrayRef = Arc::new(Int32Array::from_iter_values(0..64));
         let arr2: ArrayRef = Arc::new(Int32Array::from_iter_values(0..128));
-        storage.insert(EntryID::from(1usize), arr1).await;
-        storage.insert(EntryID::from(2usize), arr2).await;
+        storage.insert(EntryID::from(1usize), arr1).await.unwrap();
+        storage.insert(EntryID::from(2usize), arr2).await.unwrap();
 
         // Stats after insert: 2 entries, memory usage > 0, disk usage == 0
         let s = storage.stats();
@@ -1081,7 +1117,7 @@ mod tests {
         assert_eq!(s.max_memory_bytes, 10 * 1024 * 1024);
 
         // Flush to disk and verify memory usage drops and disk usage increases
-        storage.flush_all_to_disk().await;
+        storage.flush_all_to_disk().await.unwrap();
         let s2 = storage.stats();
         assert_eq!(s2.total_entries, 2);
         assert!(s2.disk_usage_bytes > 0);
@@ -1095,8 +1131,8 @@ mod tests {
         let entry_id = EntryID::from(321usize);
         let array = create_test_arrow_array(8);
 
-        store.insert(entry_id, array.clone()).await;
-        store.flush_all_to_disk().await;
+        store.insert(entry_id, array.clone()).await.unwrap();
+        store.flush_all_to_disk().await.unwrap();
         {
             let entry = store.index().get(&entry_id).unwrap();
             assert!(matches!(entry.as_ref(), CacheEntry::DiskArrow(_)));
@@ -1120,8 +1156,9 @@ mod tests {
 
         store
             .insert_inner(entry_id, CacheEntry::memory_liquid(liquid.clone()))
-            .await;
-        store.flush_all_to_disk().await;
+            .await
+            .unwrap();
+        store.flush_all_to_disk().await.unwrap();
         {
             let entry = store.index().get(&entry_id).unwrap();
             assert!(matches!(entry.as_ref(), CacheEntry::DiskLiquid(_)));
@@ -1133,5 +1170,42 @@ mod tests {
             let entry = store.index().get(&entry_id).unwrap();
             assert!(matches!(entry.as_ref(), CacheEntry::MemoryLiquid(_)));
         }
+    }
+
+    #[tokio::test]
+    async fn insert_returns_cache_full_when_memory_and_disk_are_saturated() {
+        let cache = LiquidCacheBuilder::new()
+            .with_max_memory_bytes(0)
+            .with_max_disk_bytes(0)
+            .with_squeeze_policy(Box::new(TranscodeSqueezeEvict))
+            .build()
+            .await;
+        let array: ArrayRef = Arc::new(Int32Array::from_iter_values(0..16));
+
+        let err = cache.insert(EntryID::from(900usize), array).await;
+
+        assert_eq!(err, Err(CacheFull));
+        assert!(!cache.is_cached(&EntryID::from(900usize)));
+    }
+
+    #[tokio::test]
+    async fn flush_all_to_disk_returns_cache_full_on_overflow() {
+        let cache = LiquidCacheBuilder::new()
+            .with_max_memory_bytes(1 << 20)
+            .with_max_disk_bytes(0)
+            .with_squeeze_policy(Box::new(TranscodeSqueezeEvict))
+            .build()
+            .await;
+        let entry_id = EntryID::from(901usize);
+        let array: ArrayRef = Arc::new(Int32Array::from_iter_values(0..16));
+        cache.insert(entry_id, array).await.unwrap();
+
+        let err = cache.flush_all_to_disk().await;
+
+        assert_eq!(err, Err(CacheFull));
+        assert!(matches!(
+            cache.index().get(&entry_id).unwrap().as_ref(),
+            CacheEntry::MemoryArrow(_)
+        ));
     }
 }

--- a/src/core/src/cache/mod.rs
+++ b/src/core/src/cache/mod.rs
@@ -31,6 +31,10 @@ pub use policies::{
 pub use transcode::{transcode_liquid_inner, transcode_liquid_inner_with_hint};
 pub use utils::{EntryID, LiquidCompressorStates};
 
+/// The cache could not reserve enough disk budget for a write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheFull;
+
 // Backwards-compatible module paths for existing imports.
 /// Legacy path: re-export cache policy types under `cache::cache_policies`.
 pub mod cache_policies {

--- a/src/core/src/cache/observer/mod.rs
+++ b/src/core/src/cache/observer/mod.rs
@@ -99,6 +99,16 @@ impl Observer {
         self.runtime.incr_hit_date32_expression();
     }
 
+    #[inline]
+    pub(crate) fn on_cache_full_bypass(&self) {
+        self.runtime.incr_cache_full_bypasses();
+    }
+
+    #[inline]
+    pub(crate) fn on_disk_reservation_failure(&self) {
+        self.runtime.incr_disk_reservation_failures();
+    }
+
     pub(crate) fn record_internal(&self, event: InternalEvent) {
         match event {
             InternalEvent::IoWrite { .. } => self.runtime.incr_write_io_count(),

--- a/src/core/src/cache/observer/stats.rs
+++ b/src/core/src/cache/observer/stats.rs
@@ -103,6 +103,8 @@ define_runtime_stats! {
     (hit_date32_expression_calls, "Number of `hit_date32_expression` calls.", incr_hit_date32_expression),
     (read_io_count, "Number of read IO operations.", incr_read_io_count),
     (write_io_count, "Number of write IO operations.", incr_write_io_count),
+    (cache_full_bypasses, "Number of row groups bypassed because the cache was full.", incr_cache_full_bypasses),
+    (disk_reservation_failures, "Number of failed disk budget reservations.", incr_disk_reservation_failures),
     (eval_predicate_on_liquid_failed, "Number of `eval_predicate` calls that failed on Liquid array.", incr_eval_predicate_on_liquid_failed),
     (squeezed_decompressed_count, "Number of decompressed Squeezed-Liquid entries.", __incr_squeezed_decompressed_count),
     (squeezed_total_count, "Total number of Squeezed-Liquid entries.", __incr_squeezed_total_count),
@@ -146,6 +148,8 @@ pub struct CacheStats {
     pub disk_usage_bytes: usize,
     /// Maximum memory size.
     pub max_memory_bytes: usize,
+    /// Maximum disk size.
+    pub max_disk_bytes: usize,
     /// Runtime counters snapshot.
     pub runtime: RuntimeStatsSnapshot,
 }

--- a/src/core/src/cache/policies/cache/clock.rs
+++ b/src/core/src/cache/policies/cache/clock.rs
@@ -244,12 +244,24 @@ mod tests {
         let entry_id2 = EntryID::from(2);
         let entry_id3 = EntryID::from(3);
 
-        store.insert(entry_id1, create_test_arrow_array(100)).await;
-        store.insert(entry_id2, create_test_arrow_array(100)).await;
-        store.insert(entry_id3, create_test_arrow_array(100)).await;
+        store
+            .insert(entry_id1, create_test_arrow_array(100))
+            .await
+            .unwrap();
+        store
+            .insert(entry_id2, create_test_arrow_array(100))
+            .await
+            .unwrap();
+        store
+            .insert(entry_id3, create_test_arrow_array(100))
+            .await
+            .unwrap();
 
         let entry_id4 = EntryID::from(4);
-        store.insert(entry_id4, create_test_arrow_array(100)).await;
+        store
+            .insert(entry_id4, create_test_arrow_array(100))
+            .await
+            .unwrap();
 
         let data = store.index().get(&entry_id1).unwrap();
         assert!(matches!(data.as_ref(), CacheEntry::DiskLiquid(_)));

--- a/src/core/src/cache/policies/cache/filo.rs
+++ b/src/core/src/cache/policies/cache/filo.rs
@@ -209,15 +209,27 @@ mod tests {
         let entry_id2 = EntryID::from(2);
         let entry_id3 = EntryID::from(3);
 
-        store.insert(entry_id1, create_test_arrow_array(100)).await;
+        store
+            .insert(entry_id1, create_test_arrow_array(100))
+            .await
+            .unwrap();
 
         let data = store.index().get(&entry_id1).unwrap();
         assert!(matches!(data.as_ref(), CacheEntry::MemoryArrow(_)));
-        store.insert(entry_id2, create_test_arrow_array(100)).await;
-        store.insert(entry_id3, create_test_arrow_array(100)).await;
+        store
+            .insert(entry_id2, create_test_arrow_array(100))
+            .await
+            .unwrap();
+        store
+            .insert(entry_id3, create_test_arrow_array(100))
+            .await
+            .unwrap();
 
         let entry_id4: EntryID = EntryID::from(4);
-        store.insert(entry_id4, create_test_arrow_array(100)).await;
+        store
+            .insert(entry_id4, create_test_arrow_array(100))
+            .await
+            .unwrap();
 
         assert!(store.index().get(&entry_id1).is_some());
         assert!(store.index().get(&entry_id2).is_some());

--- a/src/core/src/cache/policies/cache/lru.rs
+++ b/src/core/src/cache/policies/cache/lru.rs
@@ -371,9 +371,18 @@ mod tests {
         let entry_id2 = EntryID::from(2);
         let entry_id3 = EntryID::from(3);
 
-        store.insert(entry_id1, create_test_arrow_array(100)).await;
-        store.insert(entry_id2, create_test_arrow_array(100)).await;
-        store.insert(entry_id3, create_test_arrow_array(100)).await;
+        store
+            .insert(entry_id1, create_test_arrow_array(100))
+            .await
+            .unwrap();
+        store
+            .insert(entry_id2, create_test_arrow_array(100))
+            .await
+            .unwrap();
+        store
+            .insert(entry_id3, create_test_arrow_array(100))
+            .await
+            .unwrap();
 
         assert!(store.index().get(&entry_id1).is_some());
         assert!(store.index().get(&entry_id2).is_some());

--- a/src/core/src/cache/policies/cache/sieve.rs
+++ b/src/core/src/cache/policies/cache/sieve.rs
@@ -285,9 +285,18 @@ mod tests {
         let entry_id2 = EntryID::from(2);
         let entry_id3 = EntryID::from(3);
 
-        store.insert(entry_id1, create_test_arrow_array(100)).await;
-        store.insert(entry_id2, create_test_arrow_array(100)).await;
-        store.insert(entry_id3, create_test_arrow_array(100)).await;
+        store
+            .insert(entry_id1, create_test_arrow_array(100))
+            .await
+            .unwrap();
+        store
+            .insert(entry_id2, create_test_arrow_array(100))
+            .await
+            .unwrap();
+        store
+            .insert(entry_id3, create_test_arrow_array(100))
+            .await
+            .unwrap();
         assert!(store.index().get(&entry_id1).is_some());
         assert!(store.index().get(&entry_id2).is_some());
         assert!(store.index().get(&entry_id3).is_some());

--- a/src/core/src/cache/tests/policies.rs
+++ b/src/core/src/cache/tests/policies.rs
@@ -18,7 +18,7 @@ async fn default_policies() {
 
     for i in 0..5 {
         let entry_id = EntryID::from(i);
-        cache.insert(entry_id, test_array.clone()).await;
+        cache.insert(entry_id, test_array.clone()).await.unwrap();
     }
 
     for i in 0..5 {
@@ -43,11 +43,17 @@ async fn insert_wont_fit_cache() {
         .with_max_memory_bytes(capacity)
         .build()
         .await;
-    cache.insert(EntryID::from(0), test_array.clone()).await;
+    cache
+        .insert(EntryID::from(0), test_array.clone())
+        .await
+        .unwrap();
     let array_3x = arrow::compute::concat(&[&test_array, &test_array, &test_array]).unwrap();
     let array_9x = arrow::compute::concat(&[&array_3x, &array_3x, &array_3x]).unwrap();
     let array_27x = arrow::compute::concat(&[&array_9x, &array_9x, &array_9x]).unwrap();
-    cache.insert(EntryID::from(1), array_27x.clone()).await;
+    cache
+        .insert(EntryID::from(1), array_27x.clone())
+        .await
+        .unwrap();
     cache.get(&EntryID::from(1)).read().await.unwrap();
 
     let trace = cache.consume_event_trace();

--- a/src/core/src/cache/tests/squeezed.rs
+++ b/src/core/src/cache/tests/squeezed.rs
@@ -43,7 +43,8 @@ async fn read_squeezed_date_time() {
         cache
             .insert(entry_id, array.clone())
             .with_squeeze_hint(expression.clone())
-            .await;
+            .await
+            .unwrap();
     }
 
     for i in 0..4 {
@@ -112,7 +113,8 @@ async fn read_squeezed_variant_path() {
         cache
             .insert(entry_id, variant_array.clone())
             .with_squeeze_hint(name_expr.clone())
-            .await;
+            .await
+            .unwrap();
     }
 
     let squeezed = cache
@@ -171,9 +173,10 @@ async fn read_squeezed_int64_array() {
             cache
                 .insert(entry_id, int64_array.clone())
                 .with_squeeze_hint(expression.clone())
-                .await;
+                .await
+                .unwrap();
         } else {
-            cache.insert(entry_id, int64_array.clone()).await;
+            cache.insert(entry_id, int64_array.clone()).await.unwrap();
         }
     }
 

--- a/src/core/src/cache/utils.rs
+++ b/src/core/src/cache/utils.rs
@@ -9,13 +9,15 @@ use bytes::Bytes;
 pub struct CacheConfig {
     batch_size: usize,
     max_memory_bytes: usize,
+    max_disk_bytes: usize,
 }
 
 impl CacheConfig {
-    pub(super) fn new(batch_size: usize, max_memory_bytes: usize) -> Self {
+    pub(super) fn new(batch_size: usize, max_memory_bytes: usize, max_disk_bytes: usize) -> Self {
         Self {
             batch_size,
             max_memory_bytes,
+            max_disk_bytes,
         }
     }
 
@@ -25,6 +27,10 @@ impl CacheConfig {
 
     pub fn max_memory_bytes(&self) -> usize {
         self.max_memory_bytes
+    }
+
+    pub fn max_disk_bytes(&self) -> usize {
+        self.max_disk_bytes
     }
 }
 

--- a/src/core/study/cache_storage.rs
+++ b/src/core/study/cache_storage.rs
@@ -144,7 +144,7 @@ fn load_and_insert_referer(
             let id = EntryID::from(idx);
             ids.push(id);
             total_size += array.get_array_memory_size();
-            storage.insert(id, array).await;
+            storage.insert(id, array).await.unwrap();
             idx += 1;
         }
 

--- a/src/datafusion-local/src/lib.rs
+++ b/src/datafusion-local/src/lib.rs
@@ -155,6 +155,7 @@ impl LiquidCacheLocalBuilder {
         let cache = LiquidCacheParquet::new(
             self.batch_size,
             self.max_memory_bytes,
+            usize::MAX,
             store,
             self.cache_policy,
             self.squeeze_policy,
@@ -166,6 +167,7 @@ impl LiquidCacheLocalBuilder {
         let cache = LiquidCacheParquet::new_with_squeeze_victim_concurrency(
             self.batch_size,
             self.max_memory_bytes,
+            usize::MAX,
             store,
             self.cache_policy,
             self.squeeze_policy,

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__os_selection.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__os_selection.snap
@@ -53,6 +53,8 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 1
   write_io_count: 0
+  cache_full_bypasses: 0
+  disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 2141
   squeezed_total_count: 2164

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__provide_schema2.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__provide_schema2.snap
@@ -38,6 +38,8 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
+  cache_full_bypasses: 0
+  disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0
   squeezed_total_count: 0
@@ -181,6 +183,8 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
+  cache_full_bypasses: 0
+  disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0
   squeezed_total_count: 0
@@ -225,6 +229,8 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
+  cache_full_bypasses: 0
+  disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0
   squeezed_total_count: 0

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__provide_schema_with_filter.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__provide_schema_with_filter.snap
@@ -54,6 +54,8 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
+  cache_full_bypasses: 0
+  disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0
   squeezed_total_count: 0

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__referer_filtering.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__referer_filtering.snap
@@ -52,6 +52,8 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
+  cache_full_bypasses: 0
+  disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0
   squeezed_total_count: 0

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__single_column_filter_projection.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__single_column_filter_projection.snap
@@ -38,6 +38,8 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
+  cache_full_bypasses: 0
+  disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0
   squeezed_total_count: 0

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__url_prefix_filtering.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__url_prefix_filtering.snap
@@ -68,6 +68,8 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 1
   write_io_count: 0
+  cache_full_bypasses: 0
+  disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0
   squeezed_total_count: 0

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__url_selection_and_ordering.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__url_selection_and_ordering.snap
@@ -53,6 +53,8 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 4
   write_io_count: 0
+  cache_full_bypasses: 0
+  disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 4362
   squeezed_total_count: 8814

--- a/src/datafusion-server/src/service.rs
+++ b/src/datafusion-server/src/service.rs
@@ -65,6 +65,7 @@ impl LiquidCacheServiceInner {
             LiquidCacheParquet::new(
                 batch_size,
                 max_memory_bytes.unwrap_or(usize::MAX),
+                usize::MAX,
                 store,
                 cache_policy,
                 squeeze_policy,

--- a/src/datafusion/bench/filter_pushdown.rs
+++ b/src/datafusion/bench/filter_pushdown.rs
@@ -44,6 +44,7 @@ fn setup_cache() -> (Arc<CachedColumn>, tempfile::TempDir) {
     let cache = tokio_test::block_on(LiquidCacheParquet::new(
         BATCH_SIZE,
         1024 * 1024 * 1024, // max_memory_bytes (1GB)
+        usize::MAX,
         store,
         Box::new(LiquidPolicy::new()),
         Box::new(TranscodeSqueezeEvict),

--- a/src/datafusion/src/cache/column.rs
+++ b/src/datafusion/src/cache/column.rs
@@ -5,7 +5,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use arrow_schema::{ArrowError, DataType, Field, Schema};
-use liquid_cache::cache::{CacheExpression, LiquidCache, LiquidExpr};
+use liquid_cache::cache::{CacheExpression, CacheFull, LiquidCache, LiquidExpr};
 use parquet::arrow::arrow_reader::ArrowPredicate;
 
 use crate::{
@@ -52,6 +52,14 @@ fn infer_expression(field: &Field) -> Option<CacheExpression> {
 pub enum InsertArrowArrayError {
     /// The array is already cached.
     AlreadyCached,
+    /// The cache does not have enough disk budget to accept the array.
+    CacheFull,
+}
+
+impl From<CacheFull> for InsertArrowArrayError {
+    fn from(_: CacheFull) -> Self {
+        Self::CacheFull
+    }
 }
 
 impl CachedColumn {
@@ -190,7 +198,7 @@ impl CachedColumn {
 
         self.cache_store
             .insert(self.entry_id(batch_id).into(), array)
-            .await;
+            .await?;
         Ok(())
     }
 }

--- a/src/datafusion/src/cache/mod.rs
+++ b/src/datafusion/src/cache/mod.rs
@@ -216,6 +216,10 @@ impl CachedFile {
         self.cache_store.config().batch_size()
     }
 
+    pub(crate) fn record_cache_full_bypass(&self) {
+        self.cache_store.record_cache_full_bypass();
+    }
+
     /// Return the full file schema tracked by the cache entry.
     pub fn schema(&self) -> SchemaRef {
         Arc::clone(&self.file_schema)
@@ -244,6 +248,7 @@ impl LiquidCacheParquet {
     pub async fn new(
         batch_size: usize,
         max_memory_bytes: usize,
+        max_disk_bytes: usize,
         store: t4::Store,
         cache_policy: Box<dyn CachePolicy>,
         squeeze_policy: Box<dyn SqueezePolicy>,
@@ -252,6 +257,7 @@ impl LiquidCacheParquet {
         Self::new_with_squeeze_victim_concurrency(
             batch_size,
             max_memory_bytes,
+            max_disk_bytes,
             store,
             cache_policy,
             squeeze_policy,
@@ -263,9 +269,11 @@ impl LiquidCacheParquet {
 
     /// Create a new cache for parquet files with explicit victim squeeze concurrency.
     #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn new_with_squeeze_victim_concurrency(
         batch_size: usize,
         max_memory_bytes: usize,
+        max_disk_bytes: usize,
         store: t4::Store,
         cache_policy: Box<dyn CachePolicy>,
         squeeze_policy: Box<dyn SqueezePolicy>,
@@ -277,6 +285,7 @@ impl LiquidCacheParquet {
         let cache_storage = LiquidCacheBuilder::new()
             .with_batch_size(batch_size)
             .with_max_memory_bytes(max_memory_bytes)
+            .with_max_disk_bytes(max_disk_bytes)
             .with_squeeze_policy(squeeze_policy)
             .with_cache_policy(cache_policy)
             .with_hydration_policy(hydration_policy)
@@ -322,6 +331,11 @@ impl LiquidCacheParquet {
         self.cache_store.config().max_memory_bytes()
     }
 
+    /// Get the max disk bytes of the cache.
+    pub fn max_disk_bytes(&self) -> usize {
+        self.cache_store.config().max_disk_bytes()
+    }
+
     /// Get the memory usage of the cache in bytes.
     pub fn memory_usage_bytes(&self) -> usize {
         self.cache_store.budget().memory_usage_bytes()
@@ -365,8 +379,8 @@ impl LiquidCacheParquet {
     /// This is for admin use only.
     /// This has no guarantees that some new entry will not be inserted in the meantime, or some entries are promoted to memory again.
     /// You mostly want to use this when no one else is using the cache.
-    pub async fn flush_data(&self) {
-        self.cache_store.flush_all_to_disk().await;
+    pub async fn flush_data(&self) -> Result<(), liquid_cache::cache::CacheFull> {
+        self.cache_store.flush_all_to_disk().await
     }
 
     /// Get the storage of the cache.
@@ -408,6 +422,7 @@ mod tests {
             .unwrap();
         let cache = LiquidCacheParquet::new(
             batch_size,
+            usize::MAX,
             usize::MAX,
             store,
             Box::new(LiquidPolicy::new()),

--- a/src/datafusion/src/cache/stats.rs
+++ b/src/datafusion/src/cache/stats.rs
@@ -188,6 +188,7 @@ mod tests {
         let cache = LiquidCacheParquet::new(
             1024,
             usize::MAX,
+            usize::MAX,
             store,
             Box::new(LiquidPolicy::new()),
             Box::new(Evict),

--- a/src/datafusion/src/optimizers/lineage_opt.rs
+++ b/src/datafusion/src/optimizers/lineage_opt.rs
@@ -1098,6 +1098,7 @@ mod tests {
             LiquidCacheParquet::new(
                 1024,
                 1024 * 1024 * 1024,
+                usize::MAX,
                 store,
                 Box::new(LiquidPolicy::new()),
                 Box::new(TranscodeSqueezeEvict),

--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -172,6 +172,7 @@ mod tests {
             LiquidCacheParquet::new(
                 8192,
                 1000000,
+                usize::MAX,
                 store,
                 Box::new(LiquidPolicy::new()),
                 Box::new(TranscodeSqueezeEvict),

--- a/src/datafusion/src/reader/plantime/mod.rs
+++ b/src/datafusion/src/reader/plantime/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+pub(crate) use source::CachedMetaReaderFactory;
 pub use source::LiquidParquetSource;
 pub(crate) use source::ParquetMetadataCacheReader;
 

--- a/src/datafusion/src/reader/runtime/liquid_cache_reader.rs
+++ b/src/datafusion/src/reader/runtime/liquid_cache_reader.rs
@@ -297,6 +297,7 @@ mod tests {
         let cache = LiquidCacheParquet::new(
             batch_size,
             usize::MAX,
+            usize::MAX,
             store,
             Box::new(LiquidPolicy::new()),
             Box::new(Evict),

--- a/src/datafusion/src/reader/runtime/liquid_stream.rs
+++ b/src/datafusion/src/reader/runtime/liquid_stream.rs
@@ -4,8 +4,10 @@ use arrow::array::RecordBatch;
 use arrow_schema::{Schema, SchemaRef};
 use fastrace::Event;
 use fastrace::local::LocalSpan;
-use futures::{FutureExt, Stream, StreamExt, future::BoxFuture};
-use parquet::arrow::arrow_reader::{ArrowPredicate, ArrowReaderMetadata, ArrowReaderOptions};
+use futures::{FutureExt, Stream, StreamExt, future::BoxFuture, stream::BoxStream};
+use parquet::arrow::arrow_reader::{
+    ArrowPredicate, ArrowReaderMetadata, ArrowReaderOptions, RowFilter,
+};
 use parquet::{
     arrow::{
         ParquetRecordBatchStreamBuilder, ProjectionMask,
@@ -26,7 +28,12 @@ use super::liquid_cache_reader::LiquidCacheReader;
 use super::utils::{get_root_column_ids, limit_row_selection, offset_row_selection};
 
 type PlanResult = Option<PlanningContext>;
-type FillCacheResult = Result<(ReaderFactory, PlanningContext), ParquetError>;
+type FillCacheResult = Result<(ReaderFactory, PlanningContext, FillOutcome), ParquetError>;
+
+enum FillOutcome {
+    Filled,
+    Bypass,
+}
 
 struct ReaderFactory {
     metadata: Arc<ParquetMetaData>,
@@ -146,7 +153,7 @@ impl ReaderFactory {
         let cache_batch_size = context.cached_row_group.batch_size();
 
         if context.cache_column_ids.is_empty() || context.missing_batches.is_empty() {
-            return Ok((self, context));
+            return Ok((self, context, FillOutcome::Filled));
         }
 
         // Build row selection for the missing batches
@@ -154,7 +161,7 @@ impl ReaderFactory {
             build_selection_for_batches(&context.missing_batches, cache_batch_size, row_count);
 
         if !backfill_selection.selects_any() {
-            return Ok((self, context));
+            return Ok((self, context, FillOutcome::Filled));
         }
 
         // Clone the reader for this operation (cheap since it's Arc-based)
@@ -209,7 +216,7 @@ impl ReaderFactory {
             );
 
             let batch_id = *batch_id;
-            insert_batch_into_cache(
+            let outcome = insert_batch_into_cache(
                 &record_batch,
                 &column_ids,
                 batch_id,
@@ -218,6 +225,9 @@ impl ReaderFactory {
                 &context.cached_row_group,
             )
             .await?;
+            if matches!(outcome, InsertBatchOutcome::CacheFull) {
+                return Ok((self, context, FillOutcome::Bypass));
+            }
 
             processed_batches += 1;
         }
@@ -230,7 +240,7 @@ impl ReaderFactory {
             )));
         }
 
-        Ok((self, context))
+        Ok((self, context, FillOutcome::Filled))
     }
 }
 
@@ -353,6 +363,11 @@ fn build_selection_for_batches(
     RowSelection::from(selectors)
 }
 
+enum InsertBatchOutcome {
+    Ok,
+    CacheFull,
+}
+
 async fn insert_batch_into_cache(
     record_batch: &RecordBatch,
     column_ids: &[usize],
@@ -360,9 +375,9 @@ async fn insert_batch_into_cache(
     batch_size: usize,
     row_count: usize,
     cached_row_group: &CachedRowGroupRef,
-) -> Result<(), ParquetError> {
+) -> Result<InsertBatchOutcome, ParquetError> {
     if column_ids.is_empty() || record_batch.num_rows() == 0 {
-        return Ok(());
+        return Ok(InsertBatchOutcome::Ok);
     }
 
     debug_assert_eq!(record_batch.num_columns(), column_ids.len());
@@ -370,7 +385,7 @@ async fn insert_batch_into_cache(
     let batch_idx = usize::from(*batch_id);
     let start = batch_idx * batch_size;
     if start >= row_count {
-        return Ok(());
+        return Ok(InsertBatchOutcome::Ok);
     }
     let end = ((batch_idx + 1) * batch_size).min(row_count);
     let len = end - start;
@@ -389,18 +404,17 @@ async fn insert_batch_into_cache(
         let column = cached_row_group.get_column(*column_id as u64).unwrap();
         let array = Arc::clone(record_batch.column(col_idx));
 
-        if let Err(err) = column.insert(batch_id, array).await
-            && !matches!(err, InsertArrowArrayError::AlreadyCached)
-        {
-            return Err(ParquetError::General(format!(
-                "Failed to insert batch {} for column {} into cache: {err:?}",
-                batch_idx, column_id
-            )));
+        match column.insert(batch_id, array).await {
+            Ok(()) | Err(InsertArrowArrayError::AlreadyCached) => {
+                debug_assert!(column.is_cached(batch_id));
+            }
+            Err(InsertArrowArrayError::CacheFull) => {
+                return Ok(InsertBatchOutcome::CacheFull);
+            }
         }
-        debug_assert!(column.is_cached(batch_id));
     }
 
-    Ok(())
+    Ok(InsertBatchOutcome::Ok)
 }
 
 /// Context for planning what to read from cache vs parquet
@@ -422,6 +436,11 @@ enum StreamState {
     FillCache(BoxFuture<'static, FillCacheResult>),
     /// Decoding a batch from cache
     ReadFromCache(LiquidCacheReader),
+    /// Reading a row group directly from parquet after cache fill hit disk budget.
+    BypassParquet {
+        stream: BoxStream<'static, Result<RecordBatch, ParquetError>>,
+        filter: Option<LiquidRowFilter>,
+    },
 }
 
 impl std::fmt::Debug for StreamState {
@@ -430,6 +449,7 @@ impl std::fmt::Debug for StreamState {
             StreamState::Init => write!(f, "StreamState::Init"),
             StreamState::FillCache(_) => write!(f, "StreamState::FillingCache"),
             StreamState::ReadFromCache(_) => write!(f, "StreamState::Decoding"),
+            StreamState::BypassParquet { .. } => write!(f, "StreamState::BypassParquet"),
         }
     }
 }
@@ -675,7 +695,7 @@ impl Stream for LiquidStream {
                         return Poll::Pending;
                     }
                     Poll::Ready(result) => match result {
-                        Ok((reader_factory, context)) => {
+                        Ok((reader_factory, context, FillOutcome::Filled)) => {
                             self.reader = Some(reader_factory);
                             LocalSpan::add_event(Event::new("LiquidStream::read_from_cache"));
                             let reader_factory = self.reader.as_mut().unwrap();
@@ -689,11 +709,71 @@ impl Stream for LiquidStream {
                             );
                             self.state = StreamState::ReadFromCache(batch_reader);
                         }
+                        Ok((mut reader_factory, context, FillOutcome::Bypass)) => {
+                            LocalSpan::add_event(Event::new("LiquidStream::bypass_parquet"));
+                            reader_factory.cached_file.record_cache_full_bypass();
+                            let filter = reader_factory.filter.take();
+                            let reader_clone = reader_factory.input.clone();
+                            let reader_metadata = ArrowReaderMetadata::try_new(
+                                Arc::clone(&reader_factory.metadata),
+                                ArrowReaderOptions::new(),
+                            )
+                            .unwrap();
+                            let mut builder = ParquetRecordBatchStreamBuilder::new_with_metadata(
+                                reader_clone,
+                                reader_metadata,
+                            )
+                            .with_projection(self.projection.clone())
+                            .with_row_groups(vec![context.row_group_idx])
+                            .with_row_selection(context.selection)
+                            .with_batch_size(context.batch_size);
+                            // Push predicates into the parquet decoder so it
+                            // decodes each predicate's own columns and applies
+                            // the filter using its rebound column indices.
+                            // Clones share metric counters with the originals
+                            // (`metrics::Count`/`Time` are `Arc`-backed), so
+                            // accumulated stats are preserved when we restore
+                            // `filter` to `reader_factory` after this row group.
+                            if let Some(f) = filter.as_ref() {
+                                let predicates: Vec<Box<dyn ArrowPredicate>> = f
+                                    .predicates()
+                                    .iter()
+                                    .cloned()
+                                    .map(|p| Box::new(p) as Box<dyn ArrowPredicate>)
+                                    .collect();
+                                builder = builder.with_row_filter(RowFilter::new(predicates));
+                            }
+                            let stream = builder.build().unwrap().boxed();
+                            self.reader = Some(reader_factory);
+                            self.state = StreamState::BypassParquet { stream, filter };
+                        }
                         Err(e) => {
                             panic!("Filling cache error: {e:?}");
                         }
                     },
                 },
+                StreamState::BypassParquet { mut stream, filter } => {
+                    match Pin::new(&mut stream).poll_next(cx) {
+                        Poll::Ready(Some(Ok(batch))) => {
+                            self.state = StreamState::BypassParquet { stream, filter };
+                            if batch.num_rows() == 0 {
+                                continue;
+                            }
+                            return Poll::Ready(Some(Ok(batch)));
+                        }
+                        Poll::Ready(Some(Err(err))) => {
+                            self.state = StreamState::BypassParquet { stream, filter };
+                            return Poll::Ready(Some(Err(err)));
+                        }
+                        Poll::Ready(None) => {
+                            self.reader.as_mut().unwrap().filter = filter;
+                        }
+                        Poll::Pending => {
+                            self.state = StreamState::BypassParquet { stream, filter };
+                            return Poll::Pending;
+                        }
+                    }
+                }
             }
         }
     }
@@ -702,13 +782,25 @@ impl Stream for LiquidStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::LiquidCacheParquet;
-    use arrow::array::{ArrayRef, Int32Array};
+    use crate::cache::{CachedFileRef, LiquidCacheParquet};
+    use crate::reader::plantime::{
+        CachedMetaReaderFactory, FilterCandidateBuilder, LiquidPredicate,
+    };
+    use arrow::array::{Array, ArrayRef, Int32Array};
     use arrow_schema::{DataType, Field, Schema};
+    use datafusion::common::ScalarValue;
+    use datafusion::datasource::listing::PartitionedFile;
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::PhysicalExpr;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Column, Literal};
+    use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
     use liquid_cache::cache::AlwaysHydrate;
     use liquid_cache::cache::squeeze_policies::Evict;
     use liquid_cache::cache_policies::LiquidPolicy;
+    use object_store::local::LocalFileSystem;
+    use parquet::arrow::ArrowWriter;
     use parquet::arrow::arrow_reader::RowSelection;
+    use std::fs::File;
     use std::sync::Arc;
 
     async fn make_cache(batch_size: usize, schema: SchemaRef) -> CachedRowGroupRef {
@@ -719,6 +811,7 @@ mod tests {
         let cache = LiquidCacheParquet::new(
             batch_size,
             usize::MAX,
+            usize::MAX,
             store,
             Box::new(LiquidPolicy::new()),
             Box::new(Evict),
@@ -727,6 +820,210 @@ mod tests {
         .await;
         let file = cache.register_or_get_file("test.parquet".to_string(), schema);
         file.create_row_group(0, vec![])
+    }
+
+    fn write_two_row_group_file(path: &std::path::Path, schema: SchemaRef) {
+        let file = File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), None).unwrap();
+        let batch0 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![0, 1, 2, 3])),
+                Arc::new(Int32Array::from(vec![10, 11, 12, 13])),
+            ],
+        )
+        .unwrap();
+        let batch1 = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![4, 5, 6, 7])),
+                Arc::new(Int32Array::from(vec![14, 15, 16, 17])),
+            ],
+        )
+        .unwrap();
+        writer.write(&batch0).unwrap();
+        writer.flush().unwrap();
+        writer.write(&batch1).unwrap();
+        writer.close().unwrap();
+    }
+
+    async fn make_liquid_stream(
+        max_memory_bytes: usize,
+        max_disk_bytes: usize,
+        row_filter: Option<LiquidRowFilter>,
+    ) -> (
+        LiquidStream,
+        Arc<LiquidCacheParquet>,
+        CachedFileRef,
+        tempfile::TempDir,
+    ) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let parquet_path = tmp_dir.path().join("data.parquet");
+        write_two_row_group_file(&parquet_path, schema.clone());
+        let metadata_file = File::open(&parquet_path).unwrap();
+        let reader_metadata =
+            ArrowReaderMetadata::load(&metadata_file, ArrowReaderOptions::new()).unwrap();
+        let object_store = Arc::new(LocalFileSystem::new_with_prefix(tmp_dir.path()).unwrap());
+        let partitioned_file = PartitionedFile::new(
+            "data.parquet",
+            std::fs::metadata(&parquet_path).unwrap().len(),
+        );
+        let metrics = ExecutionPlanMetricsSet::new();
+        let input = CachedMetaReaderFactory::new(object_store).create_liquid_reader(
+            0,
+            partitioned_file,
+            None,
+            &metrics,
+        );
+
+        let store = t4::mount(tmp_dir.path().join("liquid_cache.t4"))
+            .await
+            .unwrap();
+        let cache = Arc::new(
+            LiquidCacheParquet::new(
+                4,
+                max_memory_bytes,
+                max_disk_bytes,
+                store,
+                Box::new(LiquidPolicy::new()),
+                Box::new(Evict),
+                Box::new(AlwaysHydrate::new()),
+            )
+            .await,
+        );
+        let cached_file = cache.register_or_get_file("data.parquet".to_string(), schema);
+        let projection = ProjectionMask::roots(
+            reader_metadata.metadata().file_metadata().schema_descr(),
+            [0, 1],
+        );
+        let mut builder = LiquidStreamBuilder::new(input, Arc::clone(reader_metadata.metadata()))
+            .with_batch_size(4)
+            .with_row_groups(vec![0, 1])
+            .with_projection(projection);
+        if let Some(row_filter) = row_filter {
+            builder = builder.with_row_filter(row_filter);
+        }
+        let stream = builder.build(cached_file.clone()).unwrap();
+        (stream, cache, cached_file, tmp_dir)
+    }
+
+    async fn collect_liquid_values(stream: LiquidStream) -> (Vec<i32>, Vec<i32>) {
+        let batches = stream
+            .map(|batch| batch.expect("valid liquid stream batch"))
+            .collect::<Vec<_>>()
+            .await;
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        for batch in batches {
+            let a_array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let b_array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            a.extend(a_array.iter().map(|value| value.unwrap()));
+            b.extend(b_array.iter().map(|value| value.unwrap()));
+        }
+        (a, b)
+    }
+
+    fn gt_filter(schema: SchemaRef, literal: i32) -> LiquidRowFilter {
+        gt_filter_on(schema, "a", 0, literal)
+    }
+
+    fn gt_filter_on(
+        schema: SchemaRef,
+        col_name: &str,
+        col_idx: usize,
+        literal: i32,
+    ) -> LiquidRowFilter {
+        let expr: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new(col_name, col_idx)),
+            Operator::Gt,
+            Arc::new(Literal::new(ScalarValue::Int32(Some(literal)))),
+        ));
+        let tmp_meta = tempfile::NamedTempFile::new().unwrap();
+        write_two_row_group_file(tmp_meta.path(), schema.clone());
+        let file = File::open(tmp_meta.path()).unwrap();
+        let metadata = ArrowReaderMetadata::load(&file, ArrowReaderOptions::new()).unwrap();
+        let builder = FilterCandidateBuilder::new(expr, schema);
+        let candidate = builder.build(metadata.metadata()).unwrap().unwrap();
+        let projection = candidate.projection(metadata.metadata());
+        let predicate = LiquidPredicate::try_new(candidate, projection).unwrap();
+        LiquidRowFilter::new(vec![predicate])
+    }
+
+    async fn make_liquid_stream_with_projection(
+        max_memory_bytes: usize,
+        max_disk_bytes: usize,
+        row_filter: Option<LiquidRowFilter>,
+        projection_columns: Vec<usize>,
+    ) -> (
+        LiquidStream,
+        Arc<LiquidCacheParquet>,
+        CachedFileRef,
+        tempfile::TempDir,
+    ) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let parquet_path = tmp_dir.path().join("data.parquet");
+        write_two_row_group_file(&parquet_path, schema.clone());
+        let metadata_file = File::open(&parquet_path).unwrap();
+        let reader_metadata =
+            ArrowReaderMetadata::load(&metadata_file, ArrowReaderOptions::new()).unwrap();
+        let object_store = Arc::new(LocalFileSystem::new_with_prefix(tmp_dir.path()).unwrap());
+        let partitioned_file = PartitionedFile::new(
+            "data.parquet",
+            std::fs::metadata(&parquet_path).unwrap().len(),
+        );
+        let metrics = ExecutionPlanMetricsSet::new();
+        let input = CachedMetaReaderFactory::new(object_store).create_liquid_reader(
+            0,
+            partitioned_file,
+            None,
+            &metrics,
+        );
+
+        let store = t4::mount(tmp_dir.path().join("liquid_cache.t4"))
+            .await
+            .unwrap();
+        let cache = Arc::new(
+            LiquidCacheParquet::new(
+                4,
+                max_memory_bytes,
+                max_disk_bytes,
+                store,
+                Box::new(LiquidPolicy::new()),
+                Box::new(Evict),
+                Box::new(AlwaysHydrate::new()),
+            )
+            .await,
+        );
+        let cached_file = cache.register_or_get_file("data.parquet".to_string(), schema);
+        let projection = ProjectionMask::roots(
+            reader_metadata.metadata().file_metadata().schema_descr(),
+            projection_columns,
+        );
+        let mut builder = LiquidStreamBuilder::new(input, Arc::clone(reader_metadata.metadata()))
+            .with_batch_size(4)
+            .with_row_groups(vec![0, 1])
+            .with_projection(projection);
+        if let Some(row_filter) = row_filter {
+            builder = builder.with_row_filter(row_filter);
+        }
+        let stream = builder.build(cached_file.clone()).unwrap();
+        (stream, cache, cached_file, tmp_dir)
     }
 
     async fn insert_batches(
@@ -878,5 +1175,131 @@ mod tests {
             selectors,
             vec![RowSelector::skip(16), RowSelector::select(2),]
         );
+    }
+
+    #[tokio::test]
+    async fn cache_full_bypasses_row_group_and_keeps_inserted_batches() {
+        let one_array_memory = Arc::new(Int32Array::from(vec![0, 1, 2, 3])).get_array_memory_size();
+        let (stream, cache, cached_file, _tmp_dir) =
+            make_liquid_stream(one_array_memory * 3, 0, None).await;
+
+        let (a, b) = collect_liquid_values(stream).await;
+
+        assert_eq!(a, vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(b, vec![10, 11, 12, 13, 14, 15, 16, 17]);
+        assert_eq!(cache.storage().stats().runtime.cache_full_bypasses, 1);
+
+        let row_group0 = cached_file.create_row_group(0, vec![]);
+        let row_group1 = cached_file.create_row_group(1, vec![]);
+        assert!(
+            row_group0
+                .get_column(0)
+                .unwrap()
+                .get_arrow_array_test_only(BatchID::from_raw(0))
+                .await
+                .is_some()
+        );
+        assert!(
+            row_group0
+                .get_column(1)
+                .unwrap()
+                .get_arrow_array_test_only(BatchID::from_raw(0))
+                .await
+                .is_some()
+        );
+        assert!(
+            row_group1
+                .get_column(0)
+                .unwrap()
+                .get_arrow_array_test_only(BatchID::from_raw(0))
+                .await
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_full_bypass_applies_row_filter_in_memory() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let one_array_memory = Arc::new(Int32Array::from(vec![0, 1, 2, 3])).get_array_memory_size();
+        let filter = gt_filter(schema, 2);
+        let (stream, cache, _cached_file, _tmp_dir) =
+            make_liquid_stream(one_array_memory * 3, 0, Some(filter)).await;
+
+        let (a, b) = collect_liquid_values(stream).await;
+
+        assert_eq!(a, vec![3, 4, 5, 6, 7]);
+        assert_eq!(b, vec![13, 14, 15, 16, 17]);
+        assert_eq!(cache.storage().stats().runtime.cache_full_bypasses, 1);
+    }
+
+    #[tokio::test]
+    async fn cache_full_bypasses_immediately_when_already_at_cap() {
+        let (stream, cache, cached_file, _tmp_dir) = make_liquid_stream(0, 0, None).await;
+
+        let (a, b) = collect_liquid_values(stream).await;
+
+        assert_eq!(a, vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(b, vec![10, 11, 12, 13, 14, 15, 16, 17]);
+        assert_eq!(cache.storage().stats().runtime.cache_full_bypasses, 2);
+
+        let row_group0 = cached_file.create_row_group(0, vec![]);
+        assert!(
+            row_group0
+                .get_column(0)
+                .unwrap()
+                .get_arrow_array_test_only(BatchID::from_raw(0))
+                .await
+                .is_none()
+        );
+    }
+
+    /// Reproducer: predicate references a column that is NOT in the user
+    /// projection. On the bypass path the parquet stream is built with
+    /// `self.projection.clone()` only, so the decoded batch does not even
+    /// contain the predicate's column. `LiquidRowFilter::filter_batch` then
+    /// evaluates the predicate against whatever column happens to sit at
+    /// index 0 of the batch, producing wrong results.
+    ///
+    /// File data:  a = [0..7],  b = [10..17]
+    /// Query:      SELECT a WHERE b > 13
+    /// Correct:    a = [4, 5, 6, 7]
+    /// Buggy:      predicate is `b > 13` rebound to "column index 0 of
+    ///             filter_schema"; the bypass batch is `[a]`, so the predicate
+    ///             evaluates `a > 13` -> all false -> empty result.
+    #[tokio::test]
+    async fn cache_full_bypass_evaluates_predicate_against_wrong_column() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let one_array_memory = Arc::new(Int32Array::from(vec![0, 1, 2, 3])).get_array_memory_size();
+        let filter = gt_filter_on(schema, "b", 1, 13);
+        let (stream, cache, _cached_file, _tmp_dir) =
+            make_liquid_stream_with_projection(one_array_memory * 3, 0, Some(filter), vec![0])
+                .await;
+
+        let batches = stream
+            .map(|batch| batch.expect("valid liquid stream batch"))
+            .collect::<Vec<_>>()
+            .await;
+
+        let mut a_values = Vec::new();
+        for batch in batches {
+            let arr = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            a_values.extend(arr.iter().map(|value| value.unwrap()));
+        }
+
+        // The bypass path was actually exercised.
+        assert!(cache.storage().stats().runtime.cache_full_bypasses >= 1);
+
+        // SELECT a WHERE b > 13 -> a = [4, 5, 6, 7]
+        assert_eq!(a_values, vec![4, 5, 6, 7]);
     }
 }


### PR DESCRIPTION
This is one of the most important yet very complicated refactor.

Many things can go wrong, especially around the datafusion integration: concurrency, proper filter/projection/schema etc.

This is the first phase of the 2, where we stop taking new entries when the cache is full (e.g. used up disk space).

The second phase will allow properly evicting entries from disk. 