### PR TITLE
Refactor cache miss handling, allowing disk space limit (2/3)

### DIFF
--- a/src/core/src/cache/core.rs
+++ b/src/core/src/cache/core.rs
@@ -210,11 +210,6 @@ impl LiquidCache {
         &self.observer
     }
 
-    /// Record that a parquet row group bypassed the cache because it was full.
-    pub fn record_cache_full_bypass(&self) {
-        self.observer.on_cache_full_bypass();
-    }
-
     /// Get the compressor states of the cache.
     pub fn compressor_states(&self, entry_id: &EntryID) -> Arc<LiquidCompressorStates> {
         self.metadata.get_compressor(entry_id)

--- a/src/core/src/cache/observer/mod.rs
+++ b/src/core/src/cache/observer/mod.rs
@@ -100,11 +100,6 @@ impl Observer {
     }
 
     #[inline]
-    pub(crate) fn on_cache_full_bypass(&self) {
-        self.runtime.incr_cache_full_bypasses();
-    }
-
-    #[inline]
     pub(crate) fn on_disk_reservation_failure(&self) {
         self.runtime.incr_disk_reservation_failures();
     }

--- a/src/core/src/cache/observer/stats.rs
+++ b/src/core/src/cache/observer/stats.rs
@@ -103,7 +103,6 @@ define_runtime_stats! {
     (hit_date32_expression_calls, "Number of `hit_date32_expression` calls.", incr_hit_date32_expression),
     (read_io_count, "Number of read IO operations.", incr_read_io_count),
     (write_io_count, "Number of write IO operations.", incr_write_io_count),
-    (cache_full_bypasses, "Number of row groups bypassed because the cache was full.", incr_cache_full_bypasses),
     (disk_reservation_failures, "Number of failed disk budget reservations.", incr_disk_reservation_failures),
     (eval_predicate_on_liquid_failed, "Number of `eval_predicate` calls that failed on Liquid array.", incr_eval_predicate_on_liquid_failed),
     (squeezed_decompressed_count, "Number of decompressed Squeezed-Liquid entries.", __incr_squeezed_decompressed_count),

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__os_selection.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__os_selection.snap
@@ -51,9 +51,8 @@ RuntimeStatsSnapshot:
   get_squeezed_needs_io: 1
   try_read_liquid_calls: 0
   hit_date32_expression_calls: 0
-  read_io_count: 1
+  read_io_count: 2
   write_io_count: 0
-  cache_full_bypasses: 0
   disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 2141

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__provide_schema2.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__provide_schema2.snap
@@ -38,7 +38,6 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
-  cache_full_bypasses: 0
   disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0
@@ -183,7 +182,6 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
-  cache_full_bypasses: 0
   disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0
@@ -229,7 +227,6 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
-  cache_full_bypasses: 0
   disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__provide_schema_with_filter.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__provide_schema_with_filter.snap
@@ -54,7 +54,6 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
-  cache_full_bypasses: 0
   disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__referer_filtering.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__referer_filtering.snap
@@ -35,13 +35,13 @@ values:
 stats:
 entries.total: 8
 entries.after_first_run: 8
-entries.memory.arrow: 2
-entries.memory.liquid: 6
+entries.memory.arrow: 0
+entries.memory.liquid: 8
 entries.memory.squeezed_liquid: 0
 entries.disk.liquid: 0
 entries.disk.arrow: 0
-usage.memory_bytes: 885884
-usage.disk_bytes: 729144
+usage.memory_bytes: 884561
+usage.disk_bytes: 877216
 RuntimeStatsSnapshot:
   get: 2
   get_with_selection: 2
@@ -50,9 +50,8 @@ RuntimeStatsSnapshot:
   get_squeezed_needs_io: 0
   try_read_liquid_calls: 0
   hit_date32_expression_calls: 0
-  read_io_count: 0
+  read_io_count: 5
   write_io_count: 0
-  cache_full_bypasses: 0
   disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__single_column_filter_projection.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__single_column_filter_projection.snap
@@ -38,7 +38,6 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 0
   write_io_count: 0
-  cache_full_bypasses: 0
   disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__squeeze__basic_squeeze.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__squeeze__basic_squeeze.snap
@@ -9,6 +9,8 @@ event=squeeze_begin victims=[0]
 event=squeeze_victim entry=0
 event=insert_success entry=0 kind=MemoryLiquid
 event=insert_success entry=262144 kind=MemoryArrow
+event=eval_predicate entry=0 selection=true cached=MemoryLiquid
+event=read entry=262144 selection=true expr=None cached=MemoryArrow
 event=insert_failed entry=1 kind=MemoryArrow
 event=squeeze_begin victims=[262144,0]
 event=squeeze_victim entry=262144
@@ -27,6 +29,8 @@ event=insert_success entry=262144 kind=DiskLiquid
 event=squeeze_victim entry=0
 event=insert_success entry=0 kind=DiskLiquid
 event=insert_success entry=262145 kind=MemoryArrow
+event=eval_predicate entry=1 selection=true cached=MemoryLiquid
+event=read entry=262145 selection=true expr=None cached=MemoryArrow
 event=insert_failed entry=2 kind=MemoryArrow
 event=squeeze_begin victims=[262145,1]
 event=squeeze_victim entry=262145
@@ -45,60 +49,8 @@ event=insert_success entry=262145 kind=DiskLiquid
 event=squeeze_victim entry=1
 event=insert_success entry=1 kind=DiskLiquid
 event=insert_success entry=262146 kind=MemoryArrow
-event=eval_predicate entry=0 selection=true cached=DiskLiquid
-event=io_read_liquid entry=0 bytes=63528
-event=hydrate entry=0 cached=DiskLiquid new=MemoryLiquid
-event=insert_failed entry=0 kind=MemoryLiquid
-event=squeeze_begin victims=[262146,2]
-event=squeeze_victim entry=262146
-event=insert_success entry=262146 kind=MemoryLiquid
-event=squeeze_victim entry=2
-event=io_write entry=2 kind=MemorySqueezedLiquid bytes=63528
-event=insert_success entry=2 kind=MemorySqueezedLiquid
-event=insert_success entry=0 kind=MemoryLiquid
-event=read entry=262144 selection=true expr=None cached=DiskLiquid
-event=io_read_liquid entry=262144 bytes=17448
-event=hydrate entry=262144 cached=DiskLiquid new=MemoryLiquid
-event=insert_success entry=262144 kind=MemoryLiquid
-event=eval_predicate entry=1 selection=true cached=DiskLiquid
-event=io_read_liquid entry=1 bytes=63528
-event=hydrate entry=1 cached=DiskLiquid new=MemoryLiquid
-event=insert_failed entry=1 kind=MemoryLiquid
-event=squeeze_begin victims=[262146,0,262144,2]
-event=squeeze_victim entry=262146
-event=io_write entry=262146 kind=DiskLiquid bytes=17448
-event=insert_success entry=262146 kind=DiskLiquid
-event=squeeze_victim entry=0
-event=io_write entry=0 kind=MemorySqueezedLiquid bytes=63528
-event=insert_success entry=0 kind=MemorySqueezedLiquid
-event=squeeze_victim entry=262144
-event=io_write entry=262144 kind=DiskLiquid bytes=17448
-event=insert_success entry=262144 kind=DiskLiquid
-event=squeeze_victim entry=2
-event=insert_success entry=2 kind=DiskLiquid
-event=insert_success entry=1 kind=MemoryLiquid
-event=read entry=262145 selection=true expr=None cached=DiskLiquid
-event=io_read_liquid entry=262145 bytes=17448
-event=hydrate entry=262145 cached=DiskLiquid new=MemoryLiquid
-event=insert_success entry=262145 kind=MemoryLiquid
-event=eval_predicate entry=2 selection=true cached=DiskLiquid
-event=io_read_liquid entry=2 bytes=63528
-event=hydrate entry=2 cached=DiskLiquid new=MemoryLiquid
-event=insert_failed entry=2 kind=MemoryLiquid
-event=squeeze_begin victims=[1,262145,0]
-event=squeeze_victim entry=1
-event=io_write entry=1 kind=MemorySqueezedLiquid bytes=63528
-event=insert_success entry=1 kind=MemorySqueezedLiquid
-event=squeeze_victim entry=262145
-event=io_write entry=262145 kind=DiskLiquid bytes=17448
-event=insert_success entry=262145 kind=DiskLiquid
-event=squeeze_victim entry=0
-event=insert_success entry=0 kind=DiskLiquid
-event=insert_success entry=2 kind=MemoryLiquid
-event=read entry=262146 selection=true expr=None cached=DiskLiquid
-event=io_read_liquid entry=262146 bytes=17448
-event=hydrate entry=262146 cached=DiskLiquid new=MemoryLiquid
-event=insert_success entry=262146 kind=MemoryLiquid
+event=eval_predicate entry=2 selection=true cached=MemoryLiquid
+event=read entry=262146 selection=true expr=None cached=MemoryArrow
 event=insert_success entry=4294967296 kind=MemoryArrow
 event=insert_success entry=4295229440 kind=MemoryArrow
 event=eval_predicate entry=4294967296 selection=true cached=MemoryArrow

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__squeeze__squeeze_distinct_search_phase.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__squeeze__squeeze_distinct_search_phase.snap
@@ -4,11 +4,15 @@ expression: trace
 ---
 EventTrace: [
 event=insert_success entry=2555904 kind=MemoryArrow
+event=eval_predicate entry=2555904 selection=true cached=MemoryArrow
+event=read entry=2555904 selection=true expr=None cached=MemoryArrow
 event=insert_failed entry=2555905 kind=MemoryArrow
 event=squeeze_begin victims=[2555904]
 event=squeeze_victim entry=2555904
 event=insert_success entry=2555904 kind=MemoryLiquid
 event=insert_success entry=2555905 kind=MemoryArrow
+event=eval_predicate entry=2555905 selection=true cached=MemoryArrow
+event=read entry=2555905 selection=true expr=None cached=MemoryArrow
 event=insert_failed entry=2555906 kind=MemoryArrow
 event=squeeze_begin victims=[2555905,2555904]
 event=squeeze_victim entry=2555905
@@ -17,11 +21,6 @@ event=squeeze_victim entry=2555904
 event=io_write entry=2555904 kind=MemorySqueezedLiquid bytes=27320
 event=insert_success entry=2555904 kind=MemorySqueezedLiquid
 event=insert_success entry=2555906 kind=MemoryArrow
-event=eval_predicate entry=2555904 selection=true cached=MemorySqueezedLiquid
-event=read entry=2555904 selection=true expr=None cached=MemorySqueezedLiquid
-event=io_read_squeezed_backing entry=2555904 bytes=27320
-event=eval_predicate entry=2555905 selection=true cached=MemoryLiquid
-event=read entry=2555905 selection=true expr=None cached=MemoryLiquid
 event=eval_predicate entry=2555906 selection=true cached=MemoryArrow
 event=read entry=2555906 selection=true expr=None cached=MemoryArrow
 event=insert_success entry=4297523200 kind=MemoryArrow

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__squeeze__squeeze_strings.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__squeeze__squeeze_strings.snap
@@ -15,15 +15,25 @@ event=io_write entry=851968 kind=DiskLiquid bytes=139416
 event=insert_success entry=851968 kind=DiskLiquid
 event=insert_failed entry=917504 kind=MemoryArrow
 event=insert_success entry=917504 kind=MemoryLiquid
+event=eval_predicate entry=917504 selection=true cached=MemoryLiquid
+event=read entry=851968 selection=true expr=None cached=DiskLiquid
+event=io_read_liquid entry=851968 bytes=139416
+event=hydrate entry=851968 cached=DiskLiquid new=MemoryLiquid
+event=insert_success entry=851968 kind=MemoryLiquid
 event=insert_success entry=851969 kind=MemoryArrow
 event=insert_failed entry=917505 kind=MemoryArrow
-event=squeeze_begin victims=[851969,917504]
+event=squeeze_begin victims=[851969,917504,851968]
 event=squeeze_victim entry=851969
 event=insert_success entry=851969 kind=MemoryLiquid
 event=squeeze_victim entry=917504
 event=io_write entry=917504 kind=MemorySqueezedLiquid bytes=136440
 event=insert_success entry=917504 kind=MemorySqueezedLiquid
+event=squeeze_victim entry=851968
+event=io_write entry=851968 kind=DiskLiquid bytes=139416
+event=insert_success entry=851968 kind=DiskLiquid
 event=insert_success entry=917505 kind=MemoryArrow
+event=eval_predicate entry=917505 selection=true cached=MemoryArrow
+event=read entry=851969 selection=true expr=None cached=MemoryLiquid
 event=insert_failed entry=851970 kind=MemoryArrow
 event=squeeze_begin victims=[917505,851969,917504]
 event=squeeze_victim entry=917505
@@ -49,30 +59,14 @@ event=insert_success entry=851970 kind=DiskLiquid
 event=squeeze_victim entry=917505
 event=insert_success entry=917505 kind=DiskLiquid
 event=insert_success entry=917506 kind=MemoryArrow
-event=eval_predicate entry=917504 selection=true cached=DiskLiquid
-event=io_read_liquid entry=917504 bytes=136440
-event=hydrate entry=917504 cached=DiskLiquid new=MemoryLiquid
-event=insert_failed entry=917504 kind=MemoryLiquid
-event=squeeze_begin victims=[917506]
-event=squeeze_victim entry=917506
-event=insert_success entry=917506 kind=MemoryLiquid
-event=insert_success entry=917504 kind=MemoryLiquid
-event=read entry=851968 selection=true expr=None cached=DiskLiquid
-event=io_read_liquid entry=851968 bytes=139416
-event=hydrate entry=851968 cached=DiskLiquid new=MemoryLiquid
-event=insert_success entry=851968 kind=MemoryLiquid
-event=eval_predicate entry=917505 selection=true cached=DiskLiquid
-event=io_read_liquid entry=917505 bytes=141576
-event=hydrate entry=917505 cached=DiskLiquid new=MemoryLiquid
-event=insert_success entry=917505 kind=MemoryLiquid
-event=read entry=851969 selection=true expr=None cached=DiskLiquid
-event=io_read_liquid entry=851969 bytes=139376
-event=hydrate entry=851969 cached=DiskLiquid new=MemoryLiquid
-event=insert_success entry=851969 kind=MemoryLiquid
-event=eval_predicate entry=917506 selection=true cached=MemoryLiquid
+event=eval_predicate entry=917506 selection=true cached=MemoryArrow
 event=read entry=851970 selection=true expr=None cached=DiskLiquid
 event=io_read_liquid entry=851970 bytes=146184
 event=hydrate entry=851970 cached=DiskLiquid new=MemoryLiquid
+event=insert_failed entry=851970 kind=MemoryLiquid
+event=squeeze_begin victims=[917506]
+event=squeeze_victim entry=917506
+event=insert_success entry=917506 kind=MemoryLiquid
 event=insert_success entry=851970 kind=MemoryLiquid
 event=insert_success entry=4295819264 kind=MemoryArrow
 event=insert_success entry=4295884800 kind=MemoryArrow

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__squeeze__squeeze_substrings_search.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__squeeze__squeeze_substrings_search.snap
@@ -4,11 +4,13 @@ expression: trace
 ---
 EventTrace: [
 event=insert_success entry=2555904 kind=MemoryArrow
+event=eval_predicate entry=2555904 selection=true cached=MemoryArrow
 event=insert_failed entry=2555905 kind=MemoryArrow
 event=squeeze_begin victims=[2555904]
 event=squeeze_victim entry=2555904
 event=insert_success entry=2555904 kind=MemoryLiquid
 event=insert_success entry=2555905 kind=MemoryArrow
+event=eval_predicate entry=2555905 selection=true cached=MemoryArrow
 event=insert_failed entry=2555906 kind=MemoryArrow
 event=squeeze_begin victims=[2555905,2555904]
 event=squeeze_victim entry=2555905
@@ -17,8 +19,6 @@ event=squeeze_victim entry=2555904
 event=io_write entry=2555904 kind=MemorySqueezedLiquid bytes=28612
 event=insert_success entry=2555904 kind=MemorySqueezedLiquid
 event=insert_success entry=2555906 kind=MemoryArrow
-event=eval_predicate entry=2555904 selection=true cached=MemorySqueezedLiquid
-event=eval_predicate entry=2555905 selection=true cached=MemoryLiquid
 event=eval_predicate entry=2555906 selection=true cached=MemoryArrow
 event=insert_success entry=4297523200 kind=MemoryArrow
 event=eval_predicate entry=4297523200 selection=true cached=MemoryArrow

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__squeeze__squeeze_substrings_search_title.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__squeeze__squeeze_substrings_search_title.snap
@@ -4,11 +4,13 @@ expression: trace
 ---
 EventTrace: [
 event=insert_success entry=131072 kind=MemoryArrow
+event=eval_predicate entry=131072 selection=true cached=MemoryArrow
 event=insert_failed entry=131073 kind=MemoryArrow
 event=squeeze_begin victims=[131072]
 event=squeeze_victim entry=131072
 event=insert_success entry=131072 kind=MemoryLiquid
 event=insert_success entry=131073 kind=MemoryArrow
+event=eval_predicate entry=131073 selection=true cached=MemoryArrow
 event=insert_failed entry=131074 kind=MemoryArrow
 event=squeeze_begin victims=[131073,131072]
 event=squeeze_victim entry=131073
@@ -17,10 +19,6 @@ event=squeeze_victim entry=131072
 event=io_write entry=131072 kind=MemorySqueezedLiquid bytes=257888
 event=insert_success entry=131072 kind=MemorySqueezedLiquid
 event=insert_success entry=131074 kind=MemoryArrow
-event=eval_predicate entry=131072 selection=true cached=MemorySqueezedLiquid
-event=io_read_squeezed_backing entry=131072 bytes=257888
-event=decompress_squeezed entry=131072 decompressed=1054 total=1724
-event=eval_predicate entry=131073 selection=true cached=MemoryLiquid
 event=eval_predicate entry=131074 selection=true cached=MemoryArrow
 event=insert_success entry=4295098368 kind=MemoryArrow
 event=eval_predicate entry=4295098368 selection=true cached=MemoryArrow

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__url_prefix_filtering.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__url_prefix_filtering.snap
@@ -68,7 +68,6 @@ RuntimeStatsSnapshot:
   hit_date32_expression_calls: 0
   read_io_count: 1
   write_io_count: 0
-  cache_full_bypasses: 0
   disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
   squeezed_decompressed_count: 0

--- a/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__url_selection_and_ordering.snap
+++ b/src/datafusion-local/src/tests/snapshots/liquid_cache_datafusion_local__tests__url_selection_and_ordering.snap
@@ -36,26 +36,25 @@ values:
 stats:
 entries.total: 4
 entries.after_first_run: 4
-entries.memory.arrow: 1
-entries.memory.liquid: 1
+entries.memory.arrow: 0
+entries.memory.liquid: 2
 entries.memory.squeezed_liquid: 2
 entries.disk.liquid: 0
 entries.disk.arrow: 0
-usage.memory_bytes: 227389
+usage.memory_bytes: 226744
 usage.disk_bytes: 564392
 RuntimeStatsSnapshot:
   get: 3
   get_with_selection: 3
   eval_predicate: 4
   get_squeezed_success: 0
-  get_squeezed_needs_io: 4
+  get_squeezed_needs_io: 2
   try_read_liquid_calls: 0
   hit_date32_expression_calls: 0
   read_io_count: 4
-  write_io_count: 0
-  cache_full_bypasses: 0
+  write_io_count: 2
   disk_reservation_failures: 0
   eval_predicate_on_liquid_failed: 0
-  squeezed_decompressed_count: 4362
-  squeezed_total_count: 8814
+  squeezed_decompressed_count: 2220
+  squeezed_total_count: 4486
   squeeze_io_saved: 0

--- a/src/datafusion/src/cache/mod.rs
+++ b/src/datafusion/src/cache/mod.rs
@@ -216,10 +216,6 @@ impl CachedFile {
         self.cache_store.config().batch_size()
     }
 
-    pub(crate) fn record_cache_full_bypass(&self) {
-        self.cache_store.record_cache_full_bypass();
-    }
-
     /// Return the full file schema tracked by the cache entry.
     pub fn schema(&self) -> SchemaRef {
         Arc::clone(&self.file_schema)

--- a/src/datafusion/src/reader/runtime/liquid_cache_reader.rs
+++ b/src/datafusion/src/reader/runtime/liquid_cache_reader.rs
@@ -3,16 +3,21 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use arrow::array::{Array, RecordBatch};
+use arrow::array::{Array, ArrayRef, BooleanArray, RecordBatch};
 use arrow::buffer::BooleanBuffer;
 use arrow::compute::prep_null_mask_filter;
 use arrow::record_batch::RecordBatchOptions;
-use arrow_schema::{ArrowError, SchemaRef};
-use futures::{Stream, future::BoxFuture};
-use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
+use arrow_schema::{ArrowError, Schema, SchemaRef};
+use futures::{Stream, StreamExt, future::BoxFuture, stream::BoxStream};
+use parquet::arrow::arrow_reader::{
+    ArrowPredicate, ArrowReaderMetadata, ArrowReaderOptions, RowSelection, RowSelector,
+};
+use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask};
+use parquet::errors::ParquetError;
+use parquet::file::metadata::ParquetMetaData;
 
-use crate::cache::{BatchID, CachedRowGroupRef};
-use crate::reader::plantime::LiquidRowFilter;
+use crate::cache::{BatchID, CachedRowGroupRef, InsertArrowArrayError};
+use crate::reader::plantime::{LiquidRowFilter, ParquetMetadataCacheReader};
 use crate::reader::runtime::utils::take_next_batch;
 use crate::utils::{boolean_buffer_and_then, row_selector_to_boolean_buffer};
 
@@ -22,7 +27,7 @@ pub(crate) struct LiquidCacheReader {
 }
 
 enum ReaderState {
-    Ready(LiquidCacheReaderInner),
+    Ready(Box<LiquidCacheReaderInner>),
     Processing(
         BoxFuture<
             'static,
@@ -48,27 +53,56 @@ struct LiquidCacheReaderInner {
     schema: SchemaRef,
     batch_size: usize,
     projection_columns: Vec<usize>,
+    parquet_fallback: ParquetFallback,
+    last_pull: Option<(BatchID, RecordBatch)>,
+}
+
+pub(crate) struct LiquidCacheReaderConfig {
+    pub(crate) batch_size: usize,
+    pub(crate) selection: RowSelection,
+    pub(crate) row_filter: Option<LiquidRowFilter>,
+    pub(crate) cached_row_group: CachedRowGroupRef,
+    pub(crate) projection_columns: Vec<usize>,
+    pub(crate) schema: SchemaRef,
+    pub(crate) parquet_fallback: ParquetFallbackConfig,
+}
+
+#[derive(Clone)]
+pub(crate) struct ParquetFallbackConfig {
+    pub(crate) row_group_idx: usize,
+    pub(crate) metadata: Arc<ParquetMetaData>,
+    pub(crate) input: ParquetMetadataCacheReader,
+    pub(crate) cache_projection: ProjectionMask,
+    pub(crate) cache_column_ids: Vec<usize>,
+    pub(crate) cache_batch_size: usize,
+    pub(crate) row_count: usize,
+}
+
+struct ParquetFallback {
+    row_group_idx: usize,
+    metadata: Arc<ParquetMetaData>,
+    input: ParquetMetadataCacheReader,
+    cache_projection: ProjectionMask,
+    cache_column_ids: Vec<usize>,
+    cache_batch_size: usize,
+    row_count: usize,
+    stream: Option<BoxStream<'static, Result<RecordBatch, ParquetError>>>,
+    next_batch_id: BatchID,
 }
 
 impl LiquidCacheReader {
-    pub(crate) fn new(
-        batch_size: usize,
-        selection: RowSelection,
-        row_filter: Option<LiquidRowFilter>,
-        cached_row_group: CachedRowGroupRef,
-        projection_columns: Vec<usize>,
-        schema: SchemaRef,
-    ) -> Self {
+    pub(crate) fn new(config: LiquidCacheReaderConfig) -> Self {
         let inner = LiquidCacheReaderInner::new(
-            batch_size,
-            selection,
-            cached_row_group,
-            projection_columns,
-            Arc::clone(&schema),
+            config.batch_size,
+            config.selection,
+            config.cached_row_group,
+            config.projection_columns,
+            Arc::clone(&config.schema),
+            ParquetFallback::new(config.parquet_fallback),
         );
         Self {
-            state: ReaderState::Ready(inner),
-            row_filter,
+            state: ReaderState::Ready(Box::new(inner)),
+            row_filter: config.row_filter,
         }
     }
 
@@ -96,7 +130,7 @@ impl Stream for LiquidCacheReader {
                     }
                     Poll::Ready((inner, row_filter, result)) => {
                         self.row_filter = row_filter;
-                        self.state = ReaderState::Ready(inner);
+                        self.state = ReaderState::Ready(Box::new(inner));
                         match result {
                             ProcessResult::Emit(item) => return Poll::Ready(Some(item)),
                             ProcessResult::Skip => continue,
@@ -106,6 +140,7 @@ impl Stream for LiquidCacheReader {
                 ReaderState::Ready(mut inner) => {
                     match take_next_batch(&mut inner.selection, inner.batch_size) {
                         Some(selection) => {
+                            let inner = *inner;
                             let future = inner.next_batch(self.row_filter.take(), selection);
                             self.state = ReaderState::Processing(future);
                             continue;
@@ -125,6 +160,86 @@ impl Stream for LiquidCacheReader {
     }
 }
 
+impl ParquetFallback {
+    fn new(config: ParquetFallbackConfig) -> Self {
+        Self {
+            row_group_idx: config.row_group_idx,
+            metadata: config.metadata,
+            input: config.input,
+            cache_projection: config.cache_projection,
+            cache_column_ids: config.cache_column_ids,
+            cache_batch_size: config.cache_batch_size,
+            row_count: config.row_count,
+            stream: None,
+            next_batch_id: BatchID::from_raw(0),
+        }
+    }
+
+    async fn fetch_batch(&mut self, batch_id: BatchID) -> Result<RecordBatch, ParquetError> {
+        if self.stream.is_none() || batch_id != self.next_batch_id {
+            self.rebuild_stream(batch_id)?;
+        }
+
+        let stream = self.stream.as_mut().expect("fallback stream is present");
+        let record_batch = stream.next().await.transpose()?.ok_or_else(|| {
+            ParquetError::General(format!(
+                "parquet fallback ended before batch {}",
+                *batch_id as usize
+            ))
+        })?;
+
+        self.next_batch_id = batch_id;
+        self.next_batch_id.inc();
+        Ok(record_batch)
+    }
+
+    fn rebuild_stream(&mut self, batch_id: BatchID) -> Result<(), ParquetError> {
+        let reader_metadata =
+            ArrowReaderMetadata::try_new(Arc::clone(&self.metadata), ArrowReaderOptions::new())?;
+        let row_selection =
+            build_row_selection_from(batch_id, self.cache_batch_size, self.row_count);
+
+        let stream =
+            ParquetRecordBatchStreamBuilder::new_with_metadata(self.input.clone(), reader_metadata)
+                .with_projection(self.cache_projection.clone())
+                .with_row_groups(vec![self.row_group_idx])
+                .with_batch_size(self.cache_batch_size)
+                .with_row_selection(row_selection)
+                .build()?
+                .boxed();
+
+        self.stream = Some(stream);
+        self.next_batch_id = batch_id;
+        Ok(())
+    }
+}
+
+fn build_row_selection_from(
+    batch_id: BatchID,
+    batch_size: usize,
+    row_count: usize,
+) -> RowSelection {
+    let start = usize::from(*batch_id) * batch_size;
+    let mut selectors = Vec::new();
+
+    if start > 0 {
+        selectors.push(RowSelector::skip(start.min(row_count)));
+    }
+
+    if start >= row_count {
+        return RowSelection::from(selectors);
+    }
+
+    let mut remaining = row_count - start;
+    while remaining > 0 {
+        let selected = remaining.min(batch_size);
+        selectors.push(RowSelector::select(selected));
+        remaining -= selected;
+    }
+
+    RowSelection::from(selectors)
+}
+
 impl LiquidCacheReaderInner {
     fn new(
         batch_size: usize,
@@ -132,6 +247,7 @@ impl LiquidCacheReaderInner {
         cached_row_group: CachedRowGroupRef,
         projection_columns: Vec<usize>,
         schema: SchemaRef,
+        parquet_fallback: ParquetFallback,
     ) -> Self {
         Self {
             cached_row_group,
@@ -140,6 +256,8 @@ impl LiquidCacheReaderInner {
             schema,
             batch_size,
             projection_columns,
+            parquet_fallback,
+            last_pull: None,
         }
     }
 
@@ -151,6 +269,7 @@ impl LiquidCacheReaderInner {
         Box::pin(async move {
             let mut inner = self;
             let mut row_filter = row_filter;
+            inner.last_pull = None;
 
             let result = match inner
                 .build_predicate_filter(&mut row_filter, selection)
@@ -191,7 +310,7 @@ impl LiquidCacheReaderInner {
                 break;
             }
 
-            let boolean_array = self
+            let boolean_array = match self
                 .cached_row_group
                 .evaluate_selection_with_predicate(
                     self.current_batch_id,
@@ -199,7 +318,13 @@ impl LiquidCacheReaderInner {
                     predicate,
                 )
                 .await
-                .expect("item must be in cache")?;
+            {
+                Some(result) => result?,
+                None => {
+                    self.evaluate_predicate_after_materialize(&input_selection, predicate)
+                        .await?
+                }
+            };
 
             let boolean_mask = if boolean_array.null_count() == 0 {
                 boolean_array.into_parts().0
@@ -215,7 +340,7 @@ impl LiquidCacheReaderInner {
 
     #[fastrace::trace]
     async fn read_from_cache(
-        &self,
+        &mut self,
         selection: &BooleanBuffer,
     ) -> Result<Option<RecordBatch>, ArrowError> {
         let selected_rows = selection.count_set_bits();
@@ -232,7 +357,7 @@ impl LiquidCacheReaderInner {
         }
 
         let mut arrays = Vec::with_capacity(self.projection_columns.len());
-        for &column_idx in &self.projection_columns {
+        for column_idx in self.projection_columns.clone() {
             let column = self
                 .cached_row_group
                 .get_column(column_idx as u64)
@@ -244,13 +369,18 @@ impl LiquidCacheReaderInner {
 
             let array = column
                 .get_arrow_array_with_filter(self.current_batch_id, selection)
-                .await
-                .ok_or_else(|| {
-                    ArrowError::ComputeError(format!(
-                        "column {column_idx} batch {} not cached",
-                        *self.current_batch_id as usize
-                    ))
-                })?;
+                .await;
+
+            let array = match array {
+                Some(array) => array,
+                None => {
+                    let record_batch = self
+                        .read_parquet_batch_and_fill_cache(self.current_batch_id)
+                        .await?;
+                    let array = self.parquet_array(&record_batch, column_idx)?;
+                    filter_array(array, selection)?
+                }
+            };
 
             arrays.push(array);
         }
@@ -259,6 +389,124 @@ impl LiquidCacheReaderInner {
             RecordBatch::try_new(self.schema.clone(), arrays).unwrap(),
         ))
     }
+
+    async fn read_parquet_batch_and_fill_cache(
+        &mut self,
+        batch_id: BatchID,
+    ) -> Result<RecordBatch, ArrowError> {
+        if let Some((pulled_batch_id, record_batch)) = &self.last_pull
+            && *pulled_batch_id == batch_id
+        {
+            return Ok(record_batch.clone());
+        }
+
+        let record_batch = self
+            .parquet_fallback
+            .fetch_batch(batch_id)
+            .await
+            .map_err(|e| ArrowError::ComputeError(format!("parquet fallback read failed: {e}")))?;
+
+        for (col_idx, file_column_id) in self
+            .parquet_fallback
+            .cache_column_ids
+            .iter()
+            .copied()
+            .enumerate()
+        {
+            let column = self
+                .cached_row_group
+                .get_column(file_column_id as u64)
+                .ok_or_else(|| {
+                    ArrowError::ComputeError(format!(
+                        "column {file_column_id} not present in liquid cache"
+                    ))
+                })?;
+            let array = Arc::clone(record_batch.column(col_idx));
+
+            match column.insert(batch_id, array).await {
+                Ok(()) | Err(InsertArrowArrayError::AlreadyCached) => {}
+                Err(InsertArrowArrayError::CacheFull) => {}
+            }
+        }
+
+        self.last_pull = Some((batch_id, record_batch.clone()));
+        Ok(record_batch)
+    }
+
+    async fn evaluate_predicate_after_materialize(
+        &mut self,
+        selection: &BooleanBuffer,
+        predicate: &mut crate::reader::LiquidPredicate,
+    ) -> Result<BooleanArray, ArrowError> {
+        let record_batch = self
+            .read_parquet_batch_and_fill_cache(self.current_batch_id)
+            .await?;
+
+        if let Some(result) = self
+            .cached_row_group
+            .evaluate_selection_with_predicate(self.current_batch_id, selection, predicate)
+            .await
+        {
+            return result;
+        }
+
+        let column_ids = predicate.predicate_column_ids();
+        let mut arrays = Vec::with_capacity(column_ids.len());
+        let mut fields = Vec::with_capacity(column_ids.len());
+
+        for column_id in column_ids {
+            let array = self.parquet_array(&record_batch, column_id)?;
+            arrays.push(filter_array(array, selection)?);
+
+            let field = self
+                .cached_row_group
+                .get_column(column_id as u64)
+                .ok_or_else(|| {
+                    ArrowError::ComputeError(format!(
+                        "column {column_id} not present in liquid cache"
+                    ))
+                })?
+                .field()
+                .as_ref()
+                .clone();
+            fields.push(field);
+        }
+
+        let schema = Arc::new(Schema::new(fields));
+        let predicate_batch = if arrays.is_empty() {
+            let options =
+                RecordBatchOptions::new().with_row_count(Some(selection.count_set_bits()));
+            RecordBatch::try_new_with_options(schema, arrays, &options)?
+        } else {
+            RecordBatch::try_new(schema, arrays)?
+        };
+
+        predicate.evaluate(predicate_batch)
+    }
+
+    fn parquet_array(
+        &self,
+        record_batch: &RecordBatch,
+        file_column_id: usize,
+    ) -> Result<ArrayRef, ArrowError> {
+        let position = self
+            .parquet_fallback
+            .cache_column_ids
+            .iter()
+            .position(|column_id| *column_id == file_column_id)
+            .ok_or_else(|| {
+                ArrowError::ComputeError(format!(
+                    "column {file_column_id} not present in parquet fallback projection"
+                ))
+            })?;
+
+        Ok(Arc::clone(record_batch.column(position)))
+    }
+}
+
+fn filter_array(array: ArrayRef, selection: &BooleanBuffer) -> Result<ArrayRef, ArrowError> {
+    let selection_array = BooleanArray::new(selection.clone(), None);
+    arrow::compute::filter(array.as_ref(), &selection_array)
 }
 
 #[cfg(test)]
@@ -266,11 +514,14 @@ mod tests {
     use super::*;
     use crate::{
         cache::LiquidCacheParquet,
+        reader::plantime::CachedMetaReaderFactory,
         reader::{FilterCandidateBuilder, LiquidPredicate, LiquidRowFilter},
     };
     use arrow::array::{ArrayRef, Int32Array};
     use arrow::record_batch::RecordBatch;
     use arrow_schema::{DataType, Field, Schema, SchemaRef};
+    use datafusion::datasource::listing::PartitionedFile;
+    use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
     use datafusion::{
         logical_expr::Operator,
         physical_expr::PhysicalExpr,
@@ -280,17 +531,77 @@ mod tests {
     use futures::{StreamExt, pin_mut};
     use liquid_cache::cache::{AlwaysHydrate, squeeze_policies::Evict};
     use liquid_cache::cache_policies::LiquidPolicy;
+    use object_store::local::LocalFileSystem;
     use parquet::arrow::{
-        ArrowWriter,
+        ArrowWriter, ProjectionMask,
         arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions, RowSelection, RowSelector},
     };
+    use std::fs::File;
     use std::sync::Arc;
 
-    async fn make_row_group(
+    struct TestRowGroup {
         batch_size: usize,
-        batches: &[Vec<i32>],
-    ) -> (CachedRowGroupRef, SchemaRef) {
+        row_group: CachedRowGroupRef,
+        schema: SchemaRef,
+        fallback: ParquetFallbackConfig,
+        _tmp_dir: tempfile::TempDir,
+    }
+
+    struct ReaderRequest {
+        selection: RowSelection,
+        row_filter: Option<LiquidRowFilter>,
+        projection_columns: Vec<usize>,
+        schema: SchemaRef,
+    }
+
+    impl TestRowGroup {
+        fn reader(&self, request: ReaderRequest) -> LiquidCacheReader {
+            LiquidCacheReader::new(LiquidCacheReaderConfig {
+                batch_size: self.batch_size,
+                selection: request.selection,
+                row_filter: request.row_filter,
+                cached_row_group: Arc::clone(&self.row_group),
+                projection_columns: request.projection_columns,
+                schema: request.schema,
+                parquet_fallback: self.fallback.clone(),
+            })
+        }
+    }
+
+    async fn make_row_group(batch_size: usize, batches: &[Vec<i32>]) -> TestRowGroup {
         let tmp_dir = tempfile::tempdir().unwrap();
+        let field = Arc::new(Field::new("col0", DataType::Int32, false));
+        let schema = Arc::new(Schema::new(vec![field.clone()]));
+        let parquet_path = tmp_dir.path().join("data.parquet");
+        let file = File::create(&parquet_path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, Arc::clone(&schema), None).unwrap();
+        for values in batches {
+            let array: ArrayRef = Arc::new(Int32Array::from(values.clone()));
+            let batch = RecordBatch::try_new(Arc::clone(&schema), vec![array]).unwrap();
+            writer.write(&batch).unwrap();
+        }
+        writer.close().unwrap();
+
+        let metadata_file = File::open(&parquet_path).unwrap();
+        let reader_metadata =
+            ArrowReaderMetadata::load(&metadata_file, ArrowReaderOptions::new()).unwrap();
+        let object_store = Arc::new(LocalFileSystem::new_with_prefix(tmp_dir.path()).unwrap());
+        let partitioned_file = PartitionedFile::new(
+            "data.parquet",
+            std::fs::metadata(&parquet_path).unwrap().len(),
+        );
+        let metrics = ExecutionPlanMetricsSet::new();
+        let input = CachedMetaReaderFactory::new(object_store).create_liquid_reader(
+            0,
+            partitioned_file,
+            None,
+            &metrics,
+        );
+        let projection = ProjectionMask::roots(
+            reader_metadata.metadata().file_metadata().schema_descr(),
+            [0],
+        );
+
         let store = t4::mount(tmp_dir.path().join("liquid_cache.t4"))
             .await
             .unwrap();
@@ -304,8 +615,6 @@ mod tests {
             Box::new(AlwaysHydrate::new()),
         )
         .await;
-        let field = Arc::new(Field::new("col0", DataType::Int32, false));
-        let schema = Arc::new(Schema::new(vec![field.clone()]));
         let file = cache.register_or_get_file("test".to_string(), schema.clone());
         let row_group = file.create_row_group(0, vec![]);
         let column = row_group.get_column(0).unwrap();
@@ -318,7 +627,21 @@ mod tests {
                 .expect("cache insert");
         }
 
-        (row_group, schema)
+        TestRowGroup {
+            batch_size,
+            row_group,
+            schema,
+            fallback: ParquetFallbackConfig {
+                row_group_idx: 0,
+                metadata: Arc::clone(reader_metadata.metadata()),
+                input,
+                cache_projection: projection,
+                cache_column_ids: vec![0],
+                cache_batch_size: batch_size,
+                row_count: flatten_batches(batches).len(),
+            },
+            _tmp_dir: tmp_dir,
+        }
     }
 
     fn flatten_batches(batches: &[Vec<i32>]) -> Vec<i32> {
@@ -378,11 +701,15 @@ mod tests {
     #[tokio::test]
     async fn reads_batches_in_order() {
         let batch_size = 2;
-        let (row_group, schema) = make_row_group(batch_size, &[vec![1, 2], vec![3, 4]]).await;
+        let test = make_row_group(batch_size, &[vec![1, 2], vec![3, 4]]).await;
         let selection = RowSelection::from(vec![RowSelector::select(4)]);
 
-        let reader =
-            LiquidCacheReader::new(batch_size, selection, None, row_group, vec![0], schema);
+        let reader = test.reader(ReaderRequest {
+            selection,
+            row_filter: None,
+            projection_columns: vec![0],
+            schema: Arc::clone(&test.schema),
+        });
 
         let batches = collect_batches(reader);
         assert_eq!(batches.len(), 2);
@@ -393,11 +720,15 @@ mod tests {
     #[tokio::test]
     async fn skips_unselected_batches() {
         let batch_size = 2;
-        let (row_group, schema) = make_row_group(batch_size, &[vec![1, 2], vec![3, 4]]).await;
+        let test = make_row_group(batch_size, &[vec![1, 2], vec![3, 4]]).await;
         let selection = RowSelection::from(vec![RowSelector::skip(2), RowSelector::select(2)]);
 
-        let reader =
-            LiquidCacheReader::new(batch_size, selection, None, row_group, vec![0], schema);
+        let reader = test.reader(ReaderRequest {
+            selection,
+            row_filter: None,
+            projection_columns: vec![0],
+            schema: Arc::clone(&test.schema),
+        });
 
         let batches = collect_batches(reader);
         assert_eq!(batches.len(), 1);
@@ -407,17 +738,15 @@ mod tests {
     #[tokio::test]
     async fn empty_projection_emits_schema_only_batches() {
         let batch_size = 2;
-        let (row_group, _) = make_row_group(batch_size, &[vec![10, 11]]).await;
+        let test = make_row_group(batch_size, &[vec![10, 11]]).await;
         let selection = RowSelection::from(vec![RowSelector::select(2)]);
 
-        let reader = LiquidCacheReader::new(
-            batch_size,
+        let reader = test.reader(ReaderRequest {
             selection,
-            None,
-            row_group,
-            Vec::new(),
-            Arc::new(Schema::new(Vec::<Field>::new())),
-        );
+            row_filter: None,
+            projection_columns: Vec::new(),
+            schema: Arc::new(Schema::new(Vec::<Field>::new())),
+        });
 
         let batches = collect_batches(reader);
         assert_eq!(batches.len(), 1);
@@ -429,18 +758,16 @@ mod tests {
     #[tokio::test]
     async fn into_filter_returns_stored_filter_after_completion() {
         let batch_size = 2;
-        let (row_group, schema) = make_row_group(batch_size, &[vec![1, 2]]).await;
+        let test = make_row_group(batch_size, &[vec![1, 2]]).await;
         let selection = RowSelection::from(Vec::<RowSelector>::new());
         let filter = LiquidRowFilter::new(Vec::new());
 
-        let mut reader = LiquidCacheReader::new(
-            batch_size,
+        let mut reader = test.reader(ReaderRequest {
             selection,
-            Some(filter),
-            row_group,
-            vec![0],
-            schema,
-        );
+            row_filter: Some(filter),
+            projection_columns: vec![0],
+            schema: Arc::clone(&test.schema),
+        });
 
         let waker = futures::task::noop_waker();
         let mut cx = Context::from_waker(&waker);
@@ -457,18 +784,16 @@ mod tests {
         let batches = vec![vec![1, 2], vec![3, 4]];
         let batch_size = 2;
         let all_values = flatten_batches(&batches);
-        let (row_group, schema) = make_row_group(batch_size, &batches).await;
-        let filter = make_gt_filter(Arc::clone(&schema), &all_values, 2);
+        let test = make_row_group(batch_size, &batches).await;
+        let filter = make_gt_filter(Arc::clone(&test.schema), &all_values, 2);
         let selection = RowSelection::from(vec![RowSelector::select(4)]);
 
-        let reader = LiquidCacheReader::new(
-            batch_size,
+        let reader = test.reader(ReaderRequest {
             selection,
-            Some(filter),
-            row_group,
-            vec![0],
-            schema,
-        );
+            row_filter: Some(filter),
+            projection_columns: vec![0],
+            schema: Arc::clone(&test.schema),
+        });
 
         let batches = collect_batches(reader);
         assert_eq!(batches.len(), 1);
@@ -500,18 +825,16 @@ mod tests {
         let batches = vec![vec![1, 2], vec![3, 4], vec![5, 6]];
         let batch_size = 2;
         let all_values = flatten_batches(&batches);
-        let (row_group, schema) = make_row_group(batch_size, &batches).await;
-        let filter = make_or_filter(Arc::clone(&schema), &all_values, 4, 2);
+        let test = make_row_group(batch_size, &batches).await;
+        let filter = make_or_filter(Arc::clone(&test.schema), &all_values, 4, 2);
         let selection = RowSelection::from(vec![RowSelector::select(6)]);
 
-        let reader = LiquidCacheReader::new(
-            batch_size,
+        let reader = test.reader(ReaderRequest {
             selection,
-            Some(filter),
-            row_group,
-            vec![0],
-            schema,
-        );
+            row_filter: Some(filter),
+            projection_columns: vec![0],
+            schema: Arc::clone(&test.schema),
+        });
 
         let batches = collect_batches(reader);
         assert_eq!(batches.len(), 2);
@@ -524,22 +847,20 @@ mod tests {
         let batches = vec![vec![1, 2, 3, 4]];
         let batch_size = 4;
         let all_values = flatten_batches(&batches);
-        let (row_group, schema) = make_row_group(batch_size, &batches).await;
-        let filter = make_gt_filter(Arc::clone(&schema), &all_values, 2);
+        let test = make_row_group(batch_size, &batches).await;
+        let filter = make_gt_filter(Arc::clone(&test.schema), &all_values, 2);
         let selection = RowSelection::from(vec![
             RowSelector::skip(1),
             RowSelector::select(2),
             RowSelector::skip(1),
         ]);
 
-        let reader = LiquidCacheReader::new(
-            batch_size,
+        let reader = test.reader(ReaderRequest {
             selection,
-            Some(filter),
-            row_group,
-            vec![0],
-            schema,
-        );
+            row_filter: Some(filter),
+            projection_columns: vec![0],
+            schema: Arc::clone(&test.schema),
+        });
 
         let mut batches = collect_batches(reader);
         assert_eq!(batches.len(), 1);
@@ -551,18 +872,16 @@ mod tests {
         let batches = vec![vec![1, 2]];
         let batch_size = 2;
         let all_values = flatten_batches(&batches);
-        let (row_group, schema) = make_row_group(batch_size, &batches).await;
-        let filter = make_gt_filter(Arc::clone(&schema), &all_values, 10);
+        let test = make_row_group(batch_size, &batches).await;
+        let filter = make_gt_filter(Arc::clone(&test.schema), &all_values, 10);
         let selection = RowSelection::from(vec![RowSelector::select(2)]);
 
-        let reader = LiquidCacheReader::new(
-            batch_size,
+        let reader = test.reader(ReaderRequest {
             selection,
-            Some(filter),
-            row_group,
-            vec![0],
-            schema,
-        );
+            row_filter: Some(filter),
+            projection_columns: vec![0],
+            schema: Arc::clone(&test.schema),
+        });
 
         let next_batch = futures::executor::block_on(async {
             pin_mut!(reader);

--- a/src/datafusion/src/reader/runtime/liquid_stream.rs
+++ b/src/datafusion/src/reader/runtime/liquid_stream.rs
@@ -1,17 +1,14 @@
-use crate::cache::{BatchID, CachedFileRef, CachedRowGroupRef, InsertArrowArrayError};
+use crate::cache::{CachedFileRef, CachedRowGroupRef};
 use crate::reader::plantime::{LiquidRowFilter, ParquetMetadataCacheReader};
 use arrow::array::RecordBatch;
 use arrow_schema::{Schema, SchemaRef};
 use fastrace::Event;
 use fastrace::local::LocalSpan;
-use futures::{FutureExt, Stream, StreamExt, future::BoxFuture, stream::BoxStream};
-use parquet::arrow::arrow_reader::{
-    ArrowPredicate, ArrowReaderMetadata, ArrowReaderOptions, RowFilter,
-};
+use futures::Stream;
 use parquet::{
     arrow::{
-        ParquetRecordBatchStreamBuilder, ProjectionMask,
-        arrow_reader::{RowSelection, RowSelector},
+        ProjectionMask,
+        arrow_reader::{ArrowPredicate, RowSelection, RowSelector},
     },
     errors::ParquetError,
     file::metadata::ParquetMetaData,
@@ -24,16 +21,12 @@ use std::{
     task::{Context, Poll},
 };
 
-use super::liquid_cache_reader::LiquidCacheReader;
+use super::liquid_cache_reader::{
+    LiquidCacheReader, LiquidCacheReaderConfig, ParquetFallbackConfig,
+};
 use super::utils::{get_root_column_ids, limit_row_selection, offset_row_selection};
 
 type PlanResult = Option<PlanningContext>;
-type FillCacheResult = Result<(ReaderFactory, PlanningContext, FillOutcome), ParquetError>;
-
-enum FillOutcome {
-    Filled,
-    Bypass,
-}
 
 struct ReaderFactory {
     metadata: Arc<ParquetMetaData>,
@@ -106,17 +99,10 @@ impl ReaderFactory {
             *limit -= rows_after;
         }
 
-        let row_count = meta.num_rows() as usize;
-        let cache_batch_size = self.cached_file.batch_size();
-
         let mut cache_projection = projection.clone();
         if let Some(ref predicate_projection) = predicate_projection {
             cache_projection.union(predicate_projection);
         }
-
-        let selection_for_cache = selection.clone();
-        let selection_batches =
-            collect_selection_batches(&selection_for_cache, cache_batch_size, row_count);
 
         let schema_descr = self.metadata.file_metadata().schema_descr();
         let cache_column_ids = get_root_column_ids(schema_descr, &cache_projection);
@@ -130,8 +116,6 @@ impl ReaderFactory {
             .create_row_group(row_group_idx as u64, predicate_column_ids);
 
         let projection_column_ids = get_root_column_ids(schema_descr, &projection);
-        let missing_batches =
-            compute_missing_batches(&cached_row_group, &cache_column_ids, &selection_batches);
 
         let context = PlanningContext {
             row_group_idx,
@@ -141,106 +125,9 @@ impl ReaderFactory {
             cache_projection,
             projection_column_ids,
             cache_column_ids,
-            missing_batches,
         };
 
         Some(context)
-    }
-
-    /// Fills the cache by reading missing batches from parquet using official parquet reader
-    async fn fill_cache_from_parquet(self, context: PlanningContext) -> FillCacheResult {
-        let row_count = self.metadata.row_group(context.row_group_idx).num_rows() as usize;
-        let cache_batch_size = context.cached_row_group.batch_size();
-
-        if context.cache_column_ids.is_empty() || context.missing_batches.is_empty() {
-            return Ok((self, context, FillOutcome::Filled));
-        }
-
-        // Build row selection for the missing batches
-        let backfill_selection =
-            build_selection_for_batches(&context.missing_batches, cache_batch_size, row_count);
-
-        if !backfill_selection.selects_any() {
-            return Ok((self, context, FillOutcome::Filled));
-        }
-
-        // Clone the reader for this operation (cheap since it's Arc-based)
-        let reader_clone: ParquetMetadataCacheReader = self.input.clone();
-
-        // Use official parquet async reader
-        let options = ArrowReaderOptions::new();
-        let reader_metadata = ArrowReaderMetadata::try_new(Arc::clone(&self.metadata), options)?;
-
-        let mut stream =
-            ParquetRecordBatchStreamBuilder::new_with_metadata(reader_clone, reader_metadata)
-                .with_projection(context.cache_projection.clone())
-                .with_row_groups(vec![context.row_group_idx])
-                .with_row_selection(backfill_selection)
-                .with_batch_size(cache_batch_size)
-                .build()?;
-
-        let mut processed_batches = 0usize;
-
-        // Get the original column indices in projection order
-        let column_ids = get_root_column_ids(
-            self.metadata.file_metadata().schema_descr(),
-            &context.cache_projection,
-        );
-
-        while let Some(batch_result) = stream.next().await {
-            let record_batch = batch_result?;
-            if record_batch.num_rows() == 0 {
-                continue;
-            }
-
-            let Some(batch_id) = context.missing_batches.get(processed_batches) else {
-                return Err(ParquetError::General(
-                    "parquet stream produced more batches than expected".to_string(),
-                ));
-            };
-
-            let batch_index = usize::from(**batch_id);
-            let batch_start = batch_index * cache_batch_size;
-            let expected_len = ((batch_index + 1) * cache_batch_size)
-                .min(row_count)
-                .saturating_sub(batch_start.min(row_count));
-
-            debug_assert!(
-                record_batch.num_rows() <= cache_batch_size,
-                "parquet batch larger than cache batch size"
-            );
-            debug_assert_eq!(
-                record_batch.num_rows(),
-                expected_len,
-                "parquet batch length does not match expected cache slice"
-            );
-
-            let batch_id = *batch_id;
-            let outcome = insert_batch_into_cache(
-                &record_batch,
-                &column_ids,
-                batch_id,
-                cache_batch_size,
-                row_count,
-                &context.cached_row_group,
-            )
-            .await?;
-            if matches!(outcome, InsertBatchOutcome::CacheFull) {
-                return Ok((self, context, FillOutcome::Bypass));
-            }
-
-            processed_batches += 1;
-        }
-
-        if processed_batches != context.missing_batches.len() {
-            return Err(ParquetError::General(format!(
-                "expected {} batches from parquet stream, received {}",
-                context.missing_batches.len(),
-                processed_batches
-            )));
-        }
-
-        Ok((self, context, FillOutcome::Filled))
     }
 }
 
@@ -253,170 +140,6 @@ fn build_projection_schema(file_schema: &SchemaRef, projection_column_ids: &[usi
     Arc::new(Schema::new(fields))
 }
 
-fn collect_selection_batches(
-    selection: &RowSelection,
-    batch_size: usize,
-    row_count: usize,
-) -> Vec<BatchID> {
-    let mut batches = Vec::new();
-    let mut current_row = 0usize;
-    let selectors: Vec<RowSelector> = selection.clone().into();
-
-    for selector in selectors {
-        if selector.skip {
-            current_row += selector.row_count;
-            continue;
-        }
-
-        let start = current_row;
-        let end = (current_row + selector.row_count).min(row_count);
-        if start >= end {
-            current_row = current_row.saturating_add(selector.row_count);
-            continue;
-        }
-
-        let start_batch = start / batch_size;
-        let end_batch = (end - 1) / batch_size;
-        for batch_idx in start_batch..=end_batch {
-            let batch_id = BatchID::from_raw(batch_idx as u16);
-            let is_duplicate = batches.last().is_some_and(|last| last == &batch_id);
-            if !is_duplicate {
-                batches.push(batch_id);
-            }
-        }
-        current_row += selector.row_count;
-    }
-
-    batches
-}
-
-fn compute_missing_batches(
-    cached_row_group: &CachedRowGroupRef,
-    column_ids: &[usize],
-    selection_batches: &[BatchID],
-) -> Vec<BatchID> {
-    if column_ids.is_empty() || selection_batches.is_empty() {
-        return Vec::new();
-    }
-
-    let mut columns = Vec::with_capacity(column_ids.len());
-    for &column_idx in column_ids {
-        columns.push(cached_row_group.get_column(column_idx as u64));
-    }
-
-    let mut missing = Vec::new();
-
-    'batch: for &batch_id in selection_batches {
-        for column in &columns {
-            match column {
-                Some(column) => {
-                    if !column.is_cached(batch_id) {
-                        if missing.last().is_some_and(|last| last == &batch_id) {
-                            continue 'batch;
-                        }
-                        missing.push(batch_id);
-                        continue 'batch;
-                    }
-                }
-                None => {
-                    if missing.last().is_some_and(|last| last == &batch_id) {
-                        continue 'batch;
-                    }
-                    missing.push(batch_id);
-                    continue 'batch;
-                }
-            }
-        }
-    }
-
-    missing
-}
-
-fn build_selection_for_batches(
-    batches: &[BatchID],
-    batch_size: usize,
-    row_count: usize,
-) -> RowSelection {
-    if batches.is_empty() {
-        return RowSelection::from(Vec::<RowSelector>::new());
-    }
-
-    let mut selectors = Vec::new();
-    let mut current_row = 0usize;
-
-    for batch_id in batches {
-        let batch_idx = usize::from(**batch_id);
-        let start = batch_idx * batch_size;
-        if start >= row_count {
-            continue;
-        }
-        let end = ((batch_idx + 1) * batch_size).min(row_count);
-
-        if start > current_row {
-            selectors.push(RowSelector::skip(start - current_row));
-        }
-
-        selectors.push(RowSelector::select(end - start));
-        current_row = end;
-    }
-
-    RowSelection::from(selectors)
-}
-
-enum InsertBatchOutcome {
-    Ok,
-    CacheFull,
-}
-
-async fn insert_batch_into_cache(
-    record_batch: &RecordBatch,
-    column_ids: &[usize],
-    batch_id: BatchID,
-    batch_size: usize,
-    row_count: usize,
-    cached_row_group: &CachedRowGroupRef,
-) -> Result<InsertBatchOutcome, ParquetError> {
-    if column_ids.is_empty() || record_batch.num_rows() == 0 {
-        return Ok(InsertBatchOutcome::Ok);
-    }
-
-    debug_assert_eq!(record_batch.num_columns(), column_ids.len());
-
-    let batch_idx = usize::from(*batch_id);
-    let start = batch_idx * batch_size;
-    if start >= row_count {
-        return Ok(InsertBatchOutcome::Ok);
-    }
-    let end = ((batch_idx + 1) * batch_size).min(row_count);
-    let len = end - start;
-
-    debug_assert!(
-        len <= batch_size,
-        "cache batch length exceeded configured batch size"
-    );
-    debug_assert_eq!(
-        record_batch.num_rows(),
-        len,
-        "record batch length does not match cache batch window"
-    );
-
-    for (col_idx, column_id) in column_ids.iter().enumerate() {
-        let column = cached_row_group.get_column(*column_id as u64).unwrap();
-        let array = Arc::clone(record_batch.column(col_idx));
-
-        match column.insert(batch_id, array).await {
-            Ok(()) | Err(InsertArrowArrayError::AlreadyCached) => {
-                debug_assert!(column.is_cached(batch_id));
-            }
-            Err(InsertArrowArrayError::CacheFull) => {
-                return Ok(InsertBatchOutcome::CacheFull);
-            }
-        }
-    }
-
-    Ok(InsertBatchOutcome::Ok)
-}
-
 /// Context for planning what to read from cache vs parquet
 struct PlanningContext {
     row_group_idx: usize,
@@ -426,30 +149,49 @@ struct PlanningContext {
     cache_projection: ProjectionMask,
     projection_column_ids: Vec<usize>,
     cache_column_ids: Vec<usize>,
-    missing_batches: Vec<BatchID>,
+}
+
+fn build_liquid_cache_reader(
+    reader_factory: &mut ReaderFactory,
+    context: PlanningContext,
+    schema: SchemaRef,
+) -> LiquidCacheReader {
+    let row_count = reader_factory
+        .metadata
+        .row_group(context.row_group_idx)
+        .num_rows() as usize;
+    let cache_batch_size = context.cached_row_group.batch_size();
+    LiquidCacheReader::new(LiquidCacheReaderConfig {
+        batch_size: context.batch_size,
+        selection: context.selection,
+        row_filter: reader_factory.filter.take(),
+        cached_row_group: context.cached_row_group,
+        projection_columns: context.projection_column_ids,
+        schema,
+        parquet_fallback: ParquetFallbackConfig {
+            row_group_idx: context.row_group_idx,
+            metadata: Arc::clone(&reader_factory.metadata),
+            input: reader_factory.input.clone(),
+            cache_projection: context.cache_projection,
+            cache_column_ids: context.cache_column_ids,
+            cache_batch_size,
+            row_count,
+        },
+    })
 }
 
 enum StreamState {
     /// At the start of a new row group, or the end of the parquet stream
     Init,
-    /// Reading from parquet and filling cache
-    FillCache(BoxFuture<'static, FillCacheResult>),
     /// Decoding a batch from cache
-    ReadFromCache(LiquidCacheReader),
-    /// Reading a row group directly from parquet after cache fill hit disk budget.
-    BypassParquet {
-        stream: BoxStream<'static, Result<RecordBatch, ParquetError>>,
-        filter: Option<LiquidRowFilter>,
-    },
+    ReadFromCache(Box<LiquidCacheReader>),
 }
 
 impl std::fmt::Debug for StreamState {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             StreamState::Init => write!(f, "StreamState::Init"),
-            StreamState::FillCache(_) => write!(f, "StreamState::FillingCache"),
             StreamState::ReadFromCache(_) => write!(f, "StreamState::Decoding"),
-            StreamState::BypassParquet { .. } => write!(f, "StreamState::BypassParquet"),
         }
     }
 }
@@ -623,7 +365,7 @@ impl Stream for LiquidStream {
 
             match state {
                 StreamState::ReadFromCache(mut batch_reader) => {
-                    match Pin::new(&mut batch_reader).poll_next(cx) {
+                    match Pin::new(&mut *batch_reader).poll_next(cx) {
                         Poll::Ready(Some(Ok(batch))) => {
                             self.state = StreamState::ReadFromCache(batch_reader);
                             return Poll::Ready(Some(Ok(batch)));
@@ -632,6 +374,7 @@ impl Stream for LiquidStream {
                             panic!("Decoding next batch error: {e:?}");
                         }
                         Poll::Ready(None) => {
+                            let batch_reader = *batch_reader;
                             let filter = batch_reader.into_filter();
                             self.reader.as_mut().unwrap().filter = filter;
                             // state left as Init, continue loop to plan next row group
@@ -663,114 +406,15 @@ impl Stream for LiquidStream {
                     );
                     match maybe_context {
                         Some(context) => {
-                            if !context.missing_batches.is_empty()
-                                && !context.cache_column_ids.is_empty()
-                            {
-                                LocalSpan::add_event(Event::new("LiquidStream::fill_cache"));
-                                let reader = self.reader.take().expect("lost reader");
-                                let fut = reader.fill_cache_from_parquet(context).boxed();
-                                self.state = StreamState::FillCache(fut);
-                            } else {
-                                LocalSpan::add_event(Event::new("LiquidStream::read_from_cache"));
-                                let reader_factory = self.reader.as_mut().unwrap();
-                                let batch_reader = LiquidCacheReader::new(
-                                    context.batch_size,
-                                    context.selection,
-                                    reader_factory.filter.take(),
-                                    context.cached_row_group,
-                                    context.projection_column_ids,
-                                    Arc::clone(&self.schema),
-                                );
-                                self.state = StreamState::ReadFromCache(batch_reader);
-                            }
+                            LocalSpan::add_event(Event::new("LiquidStream::read_from_cache"));
+                            let schema = Arc::clone(&self.schema);
+                            let reader_factory = self.reader.as_mut().unwrap();
+                            let batch_reader =
+                                build_liquid_cache_reader(reader_factory, context, schema);
+                            self.state = StreamState::ReadFromCache(Box::new(batch_reader));
                         }
                         None => {
                             self.state = StreamState::Init;
-                        }
-                    }
-                }
-                StreamState::FillCache(mut f) => match f.as_mut().poll(cx) {
-                    Poll::Pending => {
-                        self.state = StreamState::FillCache(f);
-                        return Poll::Pending;
-                    }
-                    Poll::Ready(result) => match result {
-                        Ok((reader_factory, context, FillOutcome::Filled)) => {
-                            self.reader = Some(reader_factory);
-                            LocalSpan::add_event(Event::new("LiquidStream::read_from_cache"));
-                            let reader_factory = self.reader.as_mut().unwrap();
-                            let batch_reader = LiquidCacheReader::new(
-                                context.batch_size,
-                                context.selection,
-                                reader_factory.filter.take(),
-                                context.cached_row_group,
-                                context.projection_column_ids,
-                                Arc::clone(&self.schema),
-                            );
-                            self.state = StreamState::ReadFromCache(batch_reader);
-                        }
-                        Ok((mut reader_factory, context, FillOutcome::Bypass)) => {
-                            LocalSpan::add_event(Event::new("LiquidStream::bypass_parquet"));
-                            reader_factory.cached_file.record_cache_full_bypass();
-                            let filter = reader_factory.filter.take();
-                            let reader_clone = reader_factory.input.clone();
-                            let reader_metadata = ArrowReaderMetadata::try_new(
-                                Arc::clone(&reader_factory.metadata),
-                                ArrowReaderOptions::new(),
-                            )
-                            .unwrap();
-                            let mut builder = ParquetRecordBatchStreamBuilder::new_with_metadata(
-                                reader_clone,
-                                reader_metadata,
-                            )
-                            .with_projection(self.projection.clone())
-                            .with_row_groups(vec![context.row_group_idx])
-                            .with_row_selection(context.selection)
-                            .with_batch_size(context.batch_size);
-                            // Push predicates into the parquet decoder so it
-                            // decodes each predicate's own columns and applies
-                            // the filter using its rebound column indices.
-                            // Clones share metric counters with the originals
-                            // (`metrics::Count`/`Time` are `Arc`-backed), so
-                            // accumulated stats are preserved when we restore
-                            // `filter` to `reader_factory` after this row group.
-                            if let Some(f) = filter.as_ref() {
-                                let predicates: Vec<Box<dyn ArrowPredicate>> = f
-                                    .predicates()
-                                    .iter()
-                                    .cloned()
-                                    .map(|p| Box::new(p) as Box<dyn ArrowPredicate>)
-                                    .collect();
-                                builder = builder.with_row_filter(RowFilter::new(predicates));
-                            }
-                            let stream = builder.build().unwrap().boxed();
-                            self.reader = Some(reader_factory);
-                            self.state = StreamState::BypassParquet { stream, filter };
-                        }
-                        Err(e) => {
-                            panic!("Filling cache error: {e:?}");
-                        }
-                    },
-                },
-                StreamState::BypassParquet { mut stream, filter } => {
-                    match Pin::new(&mut stream).poll_next(cx) {
-                        Poll::Ready(Some(Ok(batch))) => {
-                            self.state = StreamState::BypassParquet { stream, filter };
-                            if batch.num_rows() == 0 {
-                                continue;
-                            }
-                            return Poll::Ready(Some(Ok(batch)));
-                        }
-                        Poll::Ready(Some(Err(err))) => {
-                            self.state = StreamState::BypassParquet { stream, filter };
-                            return Poll::Ready(Some(Err(err)));
-                        }
-                        Poll::Ready(None) => {
-                            self.reader.as_mut().unwrap().filter = filter;
-                        }
-                        Poll::Pending => {
-                            self.state = StreamState::BypassParquet { stream, filter };
-                            return Poll::Pending;
                         }
                     }
                 }
@@ -782,7 +426,7 @@ impl Stream for LiquidStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::{CachedFileRef, LiquidCacheParquet};
+    use crate::cache::{BatchID, CachedFileRef, LiquidCacheParquet};
     use crate::reader::plantime::{
         CachedMetaReaderFactory, FilterCandidateBuilder, LiquidPredicate,
     };
@@ -794,33 +438,15 @@ mod tests {
     use datafusion::physical_expr::PhysicalExpr;
     use datafusion::physical_expr::expressions::{BinaryExpr, Column, Literal};
     use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+    use futures::StreamExt;
     use liquid_cache::cache::AlwaysHydrate;
     use liquid_cache::cache::squeeze_policies::Evict;
     use liquid_cache::cache_policies::LiquidPolicy;
     use object_store::local::LocalFileSystem;
     use parquet::arrow::ArrowWriter;
-    use parquet::arrow::arrow_reader::RowSelection;
+    use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
     use std::fs::File;
     use std::sync::Arc;
-
-    async fn make_cache(batch_size: usize, schema: SchemaRef) -> CachedRowGroupRef {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let store = t4::mount(tmp_dir.path().join("liquid_cache.t4"))
-            .await
-            .unwrap();
-        let cache = LiquidCacheParquet::new(
-            batch_size,
-            usize::MAX,
-            usize::MAX,
-            store,
-            Box::new(LiquidPolicy::new()),
-            Box::new(Evict),
-            Box::new(AlwaysHydrate::new()),
-        )
-        .await;
-        let file = cache.register_or_get_file("test.parquet".to_string(), schema);
-        file.create_row_group(0, vec![])
-    }
 
     fn write_two_row_group_file(path: &std::path::Path, schema: SchemaRef) {
         let file = File::create(path).unwrap();
@@ -844,6 +470,19 @@ mod tests {
         writer.write(&batch0).unwrap();
         writer.flush().unwrap();
         writer.write(&batch1).unwrap();
+        writer.close().unwrap();
+    }
+
+    fn write_single_row_group_file(path: &std::path::Path, schema: SchemaRef, a: Vec<i32>) {
+        let file = File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), None).unwrap();
+        let b: Vec<_> = a.iter().map(|value| value + 1000).collect();
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from(a)), Arc::new(Int32Array::from(b))],
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
         writer.close().unwrap();
     }
 
@@ -933,6 +572,23 @@ mod tests {
             b.extend(b_array.iter().map(|value| value.unwrap()));
         }
         (a, b)
+    }
+
+    async fn collect_projected_a(stream: LiquidStream) -> Vec<i32> {
+        let batches = stream
+            .map(|batch| batch.expect("valid liquid stream batch"))
+            .collect::<Vec<_>>()
+            .await;
+        let mut a = Vec::new();
+        for batch in batches {
+            let a_array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            a.extend(a_array.iter().map(|value| value.unwrap()));
+        }
+        a
     }
 
     fn gt_filter(schema: SchemaRef, literal: i32) -> LiquidRowFilter {
@@ -1026,6 +682,62 @@ mod tests {
         (stream, cache, cached_file, tmp_dir)
     }
 
+    async fn make_single_row_group_stream(
+        parquet_a: Vec<i32>,
+        projection_columns: Vec<usize>,
+    ) -> (LiquidStream, CachedFileRef, tempfile::TempDir) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let parquet_path = tmp_dir.path().join("data.parquet");
+        write_single_row_group_file(&parquet_path, schema.clone(), parquet_a);
+        let metadata_file = File::open(&parquet_path).unwrap();
+        let reader_metadata =
+            ArrowReaderMetadata::load(&metadata_file, ArrowReaderOptions::new()).unwrap();
+        let object_store = Arc::new(LocalFileSystem::new_with_prefix(tmp_dir.path()).unwrap());
+        let partitioned_file = PartitionedFile::new(
+            "data.parquet",
+            std::fs::metadata(&parquet_path).unwrap().len(),
+        );
+        let metrics = ExecutionPlanMetricsSet::new();
+        let input = CachedMetaReaderFactory::new(object_store).create_liquid_reader(
+            0,
+            partitioned_file,
+            None,
+            &metrics,
+        );
+
+        let store = t4::mount(tmp_dir.path().join("liquid_cache.t4"))
+            .await
+            .unwrap();
+        let cache = Arc::new(
+            LiquidCacheParquet::new(
+                4,
+                usize::MAX,
+                usize::MAX,
+                store,
+                Box::new(LiquidPolicy::new()),
+                Box::new(Evict),
+                Box::new(AlwaysHydrate::new()),
+            )
+            .await,
+        );
+        let cached_file = cache.register_or_get_file("data.parquet".to_string(), schema);
+        let projection = ProjectionMask::roots(
+            reader_metadata.metadata().file_metadata().schema_descr(),
+            projection_columns,
+        );
+        let stream = LiquidStreamBuilder::new(input, Arc::clone(reader_metadata.metadata()))
+            .with_batch_size(4)
+            .with_row_groups(vec![0])
+            .with_projection(projection)
+            .build(cached_file.clone())
+            .unwrap();
+        (stream, cached_file, tmp_dir)
+    }
+
     async fn insert_batches(
         row_group: &CachedRowGroupRef,
         column_id: usize,
@@ -1041,265 +753,132 @@ mod tests {
         }
     }
 
-    #[test]
-    fn collect_selection_batches_marks_all_selected_batches() {
-        let selection = RowSelection::from(vec![
-            RowSelector::select(3),
-            RowSelector::skip(2),
-            RowSelector::select(5),
-        ]);
-        let batches = collect_selection_batches(&selection, 4, 10);
-        let expected = vec![
-            BatchID::from_raw(0),
-            BatchID::from_raw(1),
-            BatchID::from_raw(2),
-        ];
-        assert_eq!(batches, expected);
-    }
-
-    #[test]
-    fn collect_selection_batches_handles_empty_selection() {
-        let selection = RowSelection::from(vec![]);
-        let batches = collect_selection_batches(&selection, 4, 10);
-        let expected: Vec<BatchID> = vec![];
-        assert_eq!(batches, expected);
-    }
-
-    #[test]
-    fn collect_selection_batches_handles_selection_beyond_row_count() {
-        let selection = RowSelection::from(vec![
-            RowSelector::select(5),  // Select 5 rows
-            RowSelector::skip(2),    // Skip 2 rows
-            RowSelector::select(10), // Select 10 rows (but only 3 rows left)
-        ]);
-        let batches = collect_selection_batches(&selection, 4, 8);
-        // Total rows: 8
-        // First selector: select 5 rows (rows 0-4) -> batches 0, 1
-        // Skip 2 rows (rows 5-6)
-        // Third selector: select 10 rows from row 7, but only 1 row left -> batch 1
-        let expected = vec![BatchID::from_raw(0), BatchID::from_raw(1)];
-        assert_eq!(batches, expected);
+    async fn is_cached(row_group: &CachedRowGroupRef, column_id: usize, batch_idx: u16) -> bool {
+        row_group
+            .get_column(column_id as u64)
+            .unwrap()
+            .get_arrow_array_test_only(BatchID::from_raw(batch_idx))
+            .await
+            .is_some()
     }
 
     #[tokio::test]
-    async fn compute_missing_batches_identifies_partial_columns() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("col_0", DataType::Int32, false),
-            Field::new("col_1", DataType::Int32, false),
-            Field::new("col_2", DataType::Int32, false),
-        ]));
-        let row_group = make_cache(4, schema.clone()).await;
-        insert_batches(&row_group, 0, &[(0, &[1, 2, 3, 4]), (2, &[9, 9, 9, 9])]).await;
-        insert_batches(&row_group, 2, &[(0, &[5, 6, 7, 8])]).await;
-
-        let selection_batches = vec![
-            BatchID::from_raw(0),
-            BatchID::from_raw(1),
-            BatchID::from_raw(2),
-        ];
-
-        let missing_for_col0 = compute_missing_batches(&row_group, &[0], &selection_batches);
-        assert_eq!(missing_for_col0, vec![BatchID::from_raw(1)]);
-
-        let missing_for_col2 = compute_missing_batches(&row_group, &[2], &selection_batches);
-        assert_eq!(
-            missing_for_col2,
-            vec![BatchID::from_raw(1), BatchID::from_raw(2),]
-        );
-
-        let missing_for_col1 = compute_missing_batches(&row_group, &[1], &selection_batches);
-        assert_eq!(
-            missing_for_col1,
-            vec![
-                BatchID::from_raw(0),
-                BatchID::from_raw(1),
-                BatchID::from_raw(2),
-            ]
-        );
-    }
-
-    #[test]
-    fn build_selection_for_batches_generates_sparse_selectors() {
-        let selection =
-            build_selection_for_batches(&[BatchID::from_raw(1), BatchID::from_raw(3)], 4, 20);
-        let selectors: Vec<RowSelector> = selection.into();
-        assert_eq!(
-            selectors,
-            vec![
-                RowSelector::skip(4),
-                RowSelector::select(4),
-                RowSelector::skip(4),
-                RowSelector::select(4),
-            ]
-        );
-    }
-
-    #[test]
-    fn build_selection_for_batches_handles_empty_batches() {
-        let selection = build_selection_for_batches(&[], 4, 20);
-        let selectors: Vec<RowSelector> = selection.into();
-        assert_eq!(selectors, vec![]);
-    }
-
-    #[test]
-    fn build_selection_for_batches_handles_batch_beyond_row_count() {
-        let selection =
-            build_selection_for_batches(&[BatchID::from_raw(5), BatchID::from_raw(6)], 4, 16);
-        let selectors: Vec<RowSelector> = selection.into();
-        // Total rows: 16, so valid batches are 0-3 (rows 0-15)
-        // Batch 5: start=20, end=min(24,16)=16, but 20 >= 16, so skipped
-        // Batch 6: start=24, end=min(28,16)=16, but 24 >= 16, so skipped
-        // Result should be empty selection
-        assert_eq!(selectors, vec![]);
-    }
-
-    #[test]
-    fn build_selection_for_batches_handles_single_batch() {
-        let selection = build_selection_for_batches(&[BatchID::from_raw(2)], 4, 20);
-        let selectors: Vec<RowSelector> = selection.into();
-        // Batch 2: rows 8-11
-        // Should skip 8 rows then select 4 rows
-        assert_eq!(
-            selectors,
-            vec![RowSelector::skip(8), RowSelector::select(4),]
-        );
-    }
-
-    #[test]
-    fn build_selection_for_batches_handles_partial_last_batch() {
-        let selection = build_selection_for_batches(&[BatchID::from_raw(4)], 4, 18);
-        let selectors: Vec<RowSelector> = selection.into();
-        // Batch 4: start=16, end=min(20,18)=18
-        // Should skip 16 rows then select 2 rows (18-16=2)
-        assert_eq!(
-            selectors,
-            vec![RowSelector::skip(16), RowSelector::select(2),]
-        );
-    }
-
-    #[tokio::test]
-    async fn cache_full_bypasses_row_group_and_keeps_inserted_batches() {
+    async fn cache_full_keeps_inserted_batches_and_skips_failed_inserts() {
         let one_array_memory = Arc::new(Int32Array::from(vec![0, 1, 2, 3])).get_array_memory_size();
-        let (stream, cache, cached_file, _tmp_dir) =
+        let (stream, _cache, cached_file, _tmp_dir) =
             make_liquid_stream(one_array_memory * 3, 0, None).await;
 
         let (a, b) = collect_liquid_values(stream).await;
 
         assert_eq!(a, vec![0, 1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(b, vec![10, 11, 12, 13, 14, 15, 16, 17]);
-        assert_eq!(cache.storage().stats().runtime.cache_full_bypasses, 1);
 
         let row_group0 = cached_file.create_row_group(0, vec![]);
         let row_group1 = cached_file.create_row_group(1, vec![]);
-        assert!(
-            row_group0
-                .get_column(0)
-                .unwrap()
-                .get_arrow_array_test_only(BatchID::from_raw(0))
-                .await
-                .is_some()
-        );
-        assert!(
-            row_group0
-                .get_column(1)
-                .unwrap()
-                .get_arrow_array_test_only(BatchID::from_raw(0))
-                .await
-                .is_some()
-        );
-        assert!(
-            row_group1
-                .get_column(0)
-                .unwrap()
-                .get_arrow_array_test_only(BatchID::from_raw(0))
-                .await
-                .is_some()
-        );
+        assert!(is_cached(&row_group0, 0, 0).await);
+        assert!(is_cached(&row_group0, 1, 0).await);
+        assert!(is_cached(&row_group1, 0, 0).await);
+        assert!(!is_cached(&row_group1, 1, 0).await);
     }
 
     #[tokio::test]
-    async fn cache_full_bypass_applies_row_filter_in_memory() {
+    async fn cache_full_with_row_filter_keeps_lookaside_results_correct() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int32, false),
             Field::new("b", DataType::Int32, false),
         ]));
         let one_array_memory = Arc::new(Int32Array::from(vec![0, 1, 2, 3])).get_array_memory_size();
         let filter = gt_filter(schema, 2);
-        let (stream, cache, _cached_file, _tmp_dir) =
+        let (stream, _cache, cached_file, _tmp_dir) =
             make_liquid_stream(one_array_memory * 3, 0, Some(filter)).await;
 
         let (a, b) = collect_liquid_values(stream).await;
 
         assert_eq!(a, vec![3, 4, 5, 6, 7]);
         assert_eq!(b, vec![13, 14, 15, 16, 17]);
-        assert_eq!(cache.storage().stats().runtime.cache_full_bypasses, 1);
+
+        let row_group0 = cached_file.create_row_group(0, vec![]);
+        let row_group1 = cached_file.create_row_group(1, vec![]);
+        assert!(is_cached(&row_group0, 0, 0).await);
+        assert!(is_cached(&row_group0, 1, 0).await);
+        assert!(is_cached(&row_group1, 0, 0).await);
+        assert!(!is_cached(&row_group1, 1, 0).await);
     }
 
     #[tokio::test]
-    async fn cache_full_bypasses_immediately_when_already_at_cap() {
-        let (stream, cache, cached_file, _tmp_dir) = make_liquid_stream(0, 0, None).await;
+    async fn mid_scan_eviction_recovers() {
+        let (stream, _cache, cached_file, _tmp_dir) = make_liquid_stream(0, 0, None).await;
 
         let (a, b) = collect_liquid_values(stream).await;
 
         assert_eq!(a, vec![0, 1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(b, vec![10, 11, 12, 13, 14, 15, 16, 17]);
-        assert_eq!(cache.storage().stats().runtime.cache_full_bypasses, 2);
 
         let row_group0 = cached_file.create_row_group(0, vec![]);
-        assert!(
-            row_group0
-                .get_column(0)
-                .unwrap()
-                .get_arrow_array_test_only(BatchID::from_raw(0))
-                .await
-                .is_none()
-        );
+        let row_group1 = cached_file.create_row_group(1, vec![]);
+        assert!(!is_cached(&row_group0, 0, 0).await);
+        assert!(!is_cached(&row_group0, 1, 0).await);
+        assert!(!is_cached(&row_group1, 0, 0).await);
+        assert!(!is_cached(&row_group1, 1, 0).await);
     }
 
-    /// Reproducer: predicate references a column that is NOT in the user
-    /// projection. On the bypass path the parquet stream is built with
-    /// `self.projection.clone()` only, so the decoded batch does not even
-    /// contain the predicate's column. `LiquidRowFilter::filter_batch` then
-    /// evaluates the predicate against whatever column happens to sit at
-    /// index 0 of the batch, producing wrong results.
-    ///
-    /// File data:  a = [0..7],  b = [10..17]
-    /// Query:      SELECT a WHERE b > 13
-    /// Correct:    a = [4, 5, 6, 7]
-    /// Buggy:      predicate is `b > 13` rebound to "column index 0 of
-    ///             filter_schema"; the bypass batch is `[a]`, so the predicate
-    ///             evaluates `a > 13` -> all false -> empty result.
     #[tokio::test]
-    async fn cache_full_bypass_evaluates_predicate_against_wrong_column() {
+    async fn predicate_fallback_uses_predicate_projection() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int32, false),
             Field::new("b", DataType::Int32, false),
         ]));
         let one_array_memory = Arc::new(Int32Array::from(vec![0, 1, 2, 3])).get_array_memory_size();
         let filter = gt_filter_on(schema, "b", 1, 13);
-        let (stream, cache, _cached_file, _tmp_dir) =
+        let (stream, _cache, cached_file, _tmp_dir) =
             make_liquid_stream_with_projection(one_array_memory * 3, 0, Some(filter), vec![0])
                 .await;
 
-        let batches = stream
-            .map(|batch| batch.expect("valid liquid stream batch"))
-            .collect::<Vec<_>>()
-            .await;
+        let a_values = collect_projected_a(stream).await;
 
-        let mut a_values = Vec::new();
-        for batch in batches {
-            let arr = batch
-                .column(0)
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .unwrap();
-            a_values.extend(arr.iter().map(|value| value.unwrap()));
-        }
-
-        // The bypass path was actually exercised.
-        assert!(cache.storage().stats().runtime.cache_full_bypasses >= 1);
-
-        // SELECT a WHERE b > 13 -> a = [4, 5, 6, 7]
         assert_eq!(a_values, vec![4, 5, 6, 7]);
+
+        let row_group0 = cached_file.create_row_group(0, vec![]);
+        let row_group1 = cached_file.create_row_group(1, vec![]);
+        assert!(is_cached(&row_group0, 0, 0).await);
+        assert!(is_cached(&row_group0, 1, 0).await);
+        assert!(is_cached(&row_group1, 0, 0).await);
+        assert!(!is_cached(&row_group1, 1, 0).await);
+    }
+
+    #[tokio::test]
+    async fn missing_column_falls_back_to_parquet() {
+        let (stream, _cache, cached_file, _tmp_dir) =
+            make_liquid_stream(usize::MAX, usize::MAX, None).await;
+        let row_group0 = cached_file.create_row_group(0, vec![]);
+        let row_group1 = cached_file.create_row_group(1, vec![]);
+        insert_batches(&row_group0, 0, &[(0, &[0, 1, 2, 3])]).await;
+        insert_batches(&row_group1, 0, &[(0, &[4, 5, 6, 7])]).await;
+
+        let (a, b) = collect_liquid_values(stream).await;
+
+        assert_eq!(a, vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(b, vec![10, 11, 12, 13, 14, 15, 16, 17]);
+        assert!(is_cached(&row_group0, 1, 0).await);
+        assert!(is_cached(&row_group1, 1, 0).await);
+    }
+
+    #[tokio::test]
+    async fn fallback_stream_advances_across_misses() {
+        let parquet_a = vec![
+            100, 101, 102, 103, 4, 5, 6, 7, 200, 201, 202, 203, 12, 13, 14, 15,
+        ];
+        let (stream, cached_file, _tmp_dir) =
+            make_single_row_group_stream(parquet_a, vec![0]).await;
+        let row_group = cached_file.create_row_group(0, vec![]);
+        insert_batches(&row_group, 0, &[(0, &[0, 1, 2, 3]), (2, &[8, 9, 10, 11])]).await;
+
+        let a_values = collect_projected_a(stream).await;
+
+        assert_eq!(a_values, (0..16).collect::<Vec<_>>());
+        assert!(is_cached(&row_group, 0, 0).await);
+        assert!(is_cached(&row_group, 0, 1).await);
+        assert!(is_cached(&row_group, 0, 2).await);
+        assert!(is_cached(&row_group, 0, 3).await);
     }
 }


### PR DESCRIPTION
This is a major refactoring of the liquid stream, so that it does not rely on the invariant that entires must be in the cache at streaming time.
Instead, it will first try to read from liquid cache, and if non-exists, it will build parquet stream and read from parquet.
