### PR TITLE
Make CI benchmark comparison robust (median warm metrics + filesystem warmup + tests)

### DIFF
--- a/.github/compare_benchmarks.py
+++ b/.github/compare_benchmarks.py
@@ -9,6 +9,7 @@ and generates a markdown report highlighting significant performance changes.
 import json
 import sys
 import argparse
+import statistics
 from typing import Dict, List, Any
 
 
@@ -47,18 +48,22 @@ def get_cold_metrics(iteration_results: List[Dict[str, Any]]) -> Dict[str, float
 
 
 def get_warm_metrics(iteration_results: List[Dict[str, Any]]) -> Dict[str, float]:
-    """Calculate average metrics from warm iterations (excluding first)."""
+    """Calculate median metrics from warm iterations (excluding first).
+
+    CI runners occasionally pause a process while it is being timed.  A median
+    keeps one such pause from turning into a reported regression.
+    """
     warm_results = iteration_results[1:] if len(iteration_results) > 1 else iteration_results
     if not warm_results:
         return {"time_millis": 0, "cache_cpu_time": 0}
 
-    avg_time = sum(r["time_millis"] for r in warm_results) / len(warm_results)
-    avg_cpu_time = sum(r.get("cache_cpu_time", 0) for r in warm_results) / len(warm_results)
+    median_time = statistics.median(r["time_millis"] for r in warm_results)
+    median_cpu_time = statistics.median(r.get("cache_cpu_time", 0) for r in warm_results)
     # No memory column in report
     
     return {
-        "time_millis": avg_time, 
-        "cache_cpu_time": avg_cpu_time,
+        "time_millis": median_time,
+        "cache_cpu_time": median_cpu_time,
     }
 
 
@@ -79,15 +84,17 @@ def format_metric_with_baseline(current: float, baseline: float, formatter_func)
     return f"{formatter_func(current)} *({formatter_func(baseline)})*"
 
 
-def format_change_percentage(current: float, baseline: float, highlight_mode: str = "none") -> str:
+def format_change_percentage(
+    current: float, baseline: float, threshold: float, highlight_mode: str = "none"
+) -> str:
     """Format percentage change and optionally highlight when slower.
 
     highlight_mode:
       - "none": never bold
-      - "slower_only": bold only if current > baseline (i.e., slower) and ≥15%
+      - "slower_only": bold only if current exceeds baseline by the threshold
     """
     change_pct = calculate_change(baseline, current)
-    if highlight_mode == "slower_only" and change_pct > 0 and abs(change_pct) >= 15.0:
+    if highlight_mode == "slower_only" and change_pct >= threshold:
         return f"**{change_pct:+.1f}%**"
     return f"{change_pct:+.1f}%"
 
@@ -195,21 +202,21 @@ def compare_benchmarks(
             comp['curr_cold_time'], comp['baseline_cold_time'], format_time
         )
         cold_change_str = format_change_percentage(
-            comp['curr_cold_time'], comp['baseline_cold_time'], highlight_mode="none"
+            comp['curr_cold_time'], comp['baseline_cold_time'], threshold, highlight_mode="none"
         )
         
         warm_time_str = format_metric_with_baseline(
             comp['curr_warm_time'], comp['baseline_warm_time'], format_time
         )
         warm_change_str = format_change_percentage(
-            comp['curr_warm_time'], comp['baseline_warm_time'], highlight_mode="slower_only"
+            comp['curr_warm_time'], comp['baseline_warm_time'], threshold, highlight_mode="slower_only"
         )
         
         cpu_time_str = format_metric_with_baseline(
             comp['curr_cpu_time'], comp['baseline_cpu_time'], format_time
         )
         cpu_change_str = format_change_percentage(
-            comp['curr_cpu_time'], comp['baseline_cpu_time'], highlight_mode="none"
+            comp['curr_cpu_time'], comp['baseline_cpu_time'], threshold, highlight_mode="none"
         )
         
         lines.append(
@@ -220,7 +227,7 @@ def compare_benchmarks(
         )
 
     # Summary focused on LiquidCache being slower than DataFusion (warm time)
-    slower_warm = [c for c in comparison if c["warm_time_change"] > 0]
+    slower_warm = [c for c in comparison if c["warm_time_change"] >= threshold]
     lines.append("")
     if slower_warm:
         lines.append(f"**⚠️ LiquidCache is slower on {len(slower_warm)} queries (warm)**")
@@ -230,18 +237,22 @@ def compare_benchmarks(
             slower_warm, key=lambda x: x["warm_time_change"], reverse=True
         )
         for c in slower_warm_sorted:
-            curr = c["curr_warm_time"]; base = c["baseline_warm_time"]
+            curr = c["curr_warm_time"]
+            base = c["baseline_warm_time"]
             pct = calculate_change(base, curr)
             lines.append(
                 f"- Q{c['query']}: warm {pct:+.1f}% "
                 f"({format_time(curr)} vs {format_time(base)})"
             )
     else:
-        lines.append("✅ LiquidCache is faster or equal on warm time for all queries")
+        lines.append(f"✅ No warm-time regression met the {threshold:.0f}% threshold")
 
     lines.append("")
     lines.append(f"*Compared {current_mode} vs {baseline_mode} on the same runner*")
-    lines.append("*Cold Time: first iteration; Warm Time: average of remaining iterations.*")
+    lines.append(
+        f"*Regressions: warm-time increases of at least {threshold:.0f}%. "
+        "Cold Time: first iteration; Warm Time: median of remaining iterations.*"
+    )
 
     return "\n".join(lines)
 

--- a/.github/test_compare_benchmarks.py
+++ b/.github/test_compare_benchmarks.py
@@ -1,0 +1,38 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("compare_benchmarks.py")
+SPEC = importlib.util.spec_from_file_location("compare_benchmarks", SCRIPT)
+compare = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(compare)
+
+
+class CompareBenchmarksTest(unittest.TestCase):
+    def test_warm_metrics_use_median(self):
+        iterations = [
+            {"time_millis": 100, "cache_cpu_time": 100},
+            {"time_millis": 10, "cache_cpu_time": 1},
+            {"time_millis": 11, "cache_cpu_time": 2},
+            {"time_millis": 500, "cache_cpu_time": 100},
+        ]
+
+        self.assertEqual(
+            compare.get_warm_metrics(iterations),
+            {"time_millis": 11, "cache_cpu_time": 2},
+        )
+
+    def test_highlight_respects_configured_threshold(self):
+        self.assertEqual(
+            compare.format_change_percentage(114, 100, 15, "slower_only"),
+            "+14.0%",
+        )
+        self.assertEqual(
+            compare.format_change_percentage(114, 100, 10, "slower_only"),
+            "**+14.0%**",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,10 +363,20 @@ jobs:
             - name: Build benchmark binary
               run: cargo build --release --bin in_process
 
+            # The LiquidCache run reads every query's columns before the DataFusion
+            # run. Without an explicit warmup, Linux's page cache makes DataFusion's
+            # "cold" measurements warm and creates a large, order-dependent bias.
+            - name: Warm filesystem cache
+              run: |
+                  env RUST_LOG=warn target/release/in_process \
+                    --manifest benchmark/clickbench/benchmark_manifest.json \
+                    --iteration 1 \
+                    --bench-mode datafusion-default
+
             - name: Run LiquidCache benchmark (in-process)
               run: |
                   mkdir -p benchmark_results
-                  env RUST_LOG=info cargo run --release --bin in_process -- \
+                  env RUST_LOG=info target/release/in_process \
                     --manifest benchmark/clickbench/benchmark_manifest.json \
                     --output benchmark_results/liquid.json \
                     --iteration 5 \
@@ -376,7 +386,7 @@ jobs:
 
             - name: Run DataFusion benchmark (plain parquet)
               run: |
-                  env RUST_LOG=info cargo run --release --bin in_process -- \
+                  env RUST_LOG=info target/release/in_process \
                     --manifest benchmark/clickbench/benchmark_manifest.json \
                     --output benchmark_results/parquet.json \
                     --iteration 5 \
@@ -384,7 +394,7 @@ jobs:
 
             - name: Run DataFusion benchmark (default config)
               run: |
-                  env RUST_LOG=info cargo run --release --bin in_process -- \
+                  env RUST_LOG=info target/release/in_process \
                     --manifest benchmark/clickbench/benchmark_manifest.json \
                     --output benchmark_results/df_default.json \
                     --iteration 5 \


### PR DESCRIPTION
### Motivation

- The CI benchmark comparison showed large, order-dependent slowdowns because LiquidCache runs first and populates the OS page cache, making the baseline look artificially faster.  
- Single outlier warm iterations from CI pauses can make the mean-driven warm metric noisy and report false regressions.  
- Make minimal, targeted changes to the comparison and CI workflow so results reflect real performance differences.

### Description

- Replace mean with median for warm-iteration metrics in `.github/compare_benchmarks.py` by importing `statistics` and updating `get_warm_metrics` to return median values.  
- Make the configured `--threshold` consistently used when highlighting regressions and computing the warm-time summary in `format_change_percentage` and the report generation.  
- Add a lightweight unit test file `.github/test_compare_benchmarks.py` that verifies median warm metrics and threshold-based highlighting.  
- Update CI in `.github/workflows/ci.yml` to build the release `in_process` binary once, run a small unmeasured DataFusion warmup to populate the filesystem page cache, and invoke `target/release/in_process` for measured runs to remove order-dependent bias.

### Testing

- Ran unit tests `python3 .github/test_compare_benchmarks.py`, and they passed (2 tests, OK).  
- Linted and checked Python files with `ruff` and `python -m py_compile`, both passed.  
- Verified `cargo check -p liquid-cache-benchmarks` for the benchmark crate succeeded.  
- A full workspace `cargo check` encountered a pre-existing environment-specific failure due to a missing generated asset (`dev/dev-tools/assets/tailwind.css`) that is unrelated to these benchmark changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a96f83694ec8332ae8d6fade89739ef)